### PR TITLE
Remove cubeb_stream_reset_default_device API.

### DIFF
--- a/cubeb-api/Cargo.toml
+++ b/cubeb-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 readme = "README.md"
@@ -19,4 +19,4 @@ circle-ci = { repository = "djg/cubeb-rs" }
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
 
 [dependencies]
-cubeb-core = { path = "../cubeb-core", version = "0.8.0" }
+cubeb-core = { path = "../cubeb-core", version = "0.9.0" }

--- a/cubeb-backend/Cargo.toml
+++ b/cubeb-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-backend"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]
@@ -18,4 +18,4 @@ circle-ci = { repository = "djg/cubeb-rs" }
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
 
 [dependencies]
-cubeb-core = { path = "../cubeb-core", version = "0.8.0" }
+cubeb-core = { path = "../cubeb-core", version = "0.9.0" }

--- a/cubeb-backend/src/capi.rs
+++ b/cubeb-backend/src/capi.rs
@@ -45,8 +45,6 @@ macro_rules! capi_new(
             stream_destroy: Some($crate::capi::capi_stream_destroy::<$stm>),
             stream_start: Some($crate::capi::capi_stream_start::<$stm>),
             stream_stop: Some($crate::capi::capi_stream_stop::<$stm>),
-            stream_reset_default_device:
-                Some($crate::capi::capi_stream_reset_default_device::<$stm>),
             stream_get_position: Some($crate::capi::capi_stream_get_position::<$stm>),
             stream_get_latency: Some($crate::capi::capi_stream_get_latency::<$stm>),
             stream_get_input_latency: Some($crate::capi::capi_stream_get_input_latency::<$stm>),
@@ -186,15 +184,6 @@ pub unsafe extern "C" fn capi_stream_stop<STM: StreamOps>(s: *mut ffi::cubeb_str
     let stm = &mut *(s as *mut STM);
 
     _try!(stm.stop());
-    ffi::CUBEB_OK
-}
-
-pub unsafe extern "C" fn capi_stream_reset_default_device<STM: StreamOps>(
-    s: *mut ffi::cubeb_stream,
-) -> c_int {
-    let stm = &mut *(s as *mut STM);
-
-    _try!(stm.reset_default_device());
     ffi::CUBEB_OK
 }
 

--- a/cubeb-backend/src/ops.rs
+++ b/cubeb-backend/src/ops.rs
@@ -57,8 +57,6 @@ pub struct Ops {
     pub stream_destroy: Option<unsafe extern "C" fn(stream: *mut ffi::cubeb_stream)>,
     pub stream_start: Option<unsafe extern "C" fn(stream: *mut ffi::cubeb_stream) -> c_int>,
     pub stream_stop: Option<unsafe extern "C" fn(stream: *mut ffi::cubeb_stream) -> c_int>,
-    pub stream_reset_default_device:
-        Option<unsafe extern "C" fn(stream: *mut ffi::cubeb_stream) -> c_int>,
     pub stream_get_position:
         Option<unsafe extern "C" fn(stream: *mut ffi::cubeb_stream, position: *mut u64) -> c_int>,
     pub stream_get_latency:

--- a/cubeb-backend/src/traits.rs
+++ b/cubeb-backend/src/traits.rs
@@ -45,7 +45,6 @@ pub trait ContextOps {
 pub trait StreamOps {
     fn start(&mut self) -> Result<()>;
     fn stop(&mut self) -> Result<()>;
-    fn reset_default_device(&mut self) -> Result<()>;
     fn position(&mut self) -> Result<u64>;
     fn latency(&mut self) -> Result<u32>;
     fn input_latency(&mut self) -> Result<u32>;

--- a/cubeb-backend/tests/test_capi.rs
+++ b/cubeb-backend/tests/test_capi.rs
@@ -91,9 +91,6 @@ impl StreamOps for TestStream {
     fn stop(&mut self) -> Result<()> {
         Ok(())
     }
-    fn reset_default_device(&mut self) -> Result<()> {
-        Ok(())
-    }
     fn position(&mut self) -> Result<u64> {
         Ok(0u64)
     }

--- a/cubeb-core/Cargo.toml
+++ b/cubeb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-core"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]
@@ -19,4 +19,4 @@ gecko-in-tree = ["cubeb-sys/gecko-in-tree"]
 
 [dependencies]
 bitflags = "1.2.0"
-cubeb-sys = { path = "../cubeb-sys", version = "0.8.0" }
+cubeb-sys = { path = "../cubeb-sys", version = "0.9.0" }

--- a/cubeb-core/src/stream.rs
+++ b/cubeb-core/src/stream.rs
@@ -119,11 +119,6 @@ impl StreamRef {
         unsafe { call!(ffi::cubeb_stream_stop(self.as_ptr())) }
     }
 
-    /// Reset stream to the default device.
-    pub fn reset_default_device(&self) -> Result<()> {
-        unsafe { call!(ffi::cubeb_stream_reset_default_device(self.as_ptr())) }
-    }
-
     /// Get the current stream playback position.
     pub fn position(&self) -> Result<u64> {
         let mut position = 0u64;

--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-sys"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 repository = "https://github.com/djg/cubeb-rs"
 license = "ISC"

--- a/cubeb-sys/src/stream.rs
+++ b/cubeb-sys/src/stream.rs
@@ -63,7 +63,6 @@ extern "C" {
     pub fn cubeb_stream_destroy(stream: *mut cubeb_stream);
     pub fn cubeb_stream_start(stream: *mut cubeb_stream) -> c_int;
     pub fn cubeb_stream_stop(stream: *mut cubeb_stream) -> c_int;
-    pub fn cubeb_stream_reset_default_device(stream: *mut cubeb_stream) -> c_int;
     pub fn cubeb_stream_get_position(stream: *mut cubeb_stream, position: *mut u64) -> c_int;
     pub fn cubeb_stream_get_latency(stream: *mut cubeb_stream, latency: *mut c_uint) -> c_int;
     pub fn cubeb_stream_get_input_latency(stream: *mut cubeb_stream, latency: *mut c_uint) -> c_int;


### PR DESCRIPTION
See https://github.com/mozilla/cubeb/pull/641

This also bumps cubeb-rs to 0.9.0.