### PR TITLE
Fix clippy warnings and enable on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,15 +29,16 @@ jobs:
         submodules: recursive
 
     - name: Install Rust
-      run: rustup toolchain install ${{ matrix.rust }} --profile minimal --component rustfmt
+      run: rustup toolchain install ${{ matrix.rust }} --profile minimal --component rustfmt clippy
 
     - name: Check format
       shell: bash
       run: rustup run ${{ matrix.rust }} cargo fmt --all -- --check
 
-#    - name: Clippy
-#      shell: bash
-#      run: rustup run ${{ matrix.rust }} cargo clippy --all -- -D warnings
+    # Skip clippy checks for `systest`
+    - name: Clippy
+      shell: bash
+      run: rustup run ${{ matrix.rust }} cargo clippy -p cubeb -p cubeb-backend -p cubeb-core -p cubeb-sys -- -D warnings
 
     - name: Build
       shell: bash

--- a/cubeb-api/src/frame.rs
+++ b/cubeb-api/src/frame.rs
@@ -1,7 +1,5 @@
 //! Frame utilities
 
-use std::{mem, slice};
-
 /// A `Frame` is a collection of samples which have a a specific
 /// layout represented by `ChannelLayout`
 pub trait Frame {}
@@ -25,16 +23,3 @@ pub struct StereoFrame<T> {
 }
 
 impl<T> Frame for StereoFrame<T> {}
-
-pub unsafe fn frame_from_bytes<F: Frame>(bytes: &[u8]) -> &[F] {
-    debug_assert_eq!(bytes.len() % mem::size_of::<F>(), 0);
-    slice::from_raw_parts(
-        bytes.as_ptr() as *const F,
-        bytes.len() / mem::size_of::<F>(),
-    )
-}
-
-pub unsafe fn frame_from_bytes_mut<F: Frame>(bytes: &mut [u8]) -> &mut [F] {
-    debug_assert!(bytes.len() % mem::size_of::<F>() == 0);
-    slice::from_raw_parts_mut(bytes.as_ptr() as *mut F, bytes.len() / mem::size_of::<F>())
-}

--- a/cubeb-api/src/stream.rs
+++ b/cubeb-api/src/stream.rs
@@ -114,15 +114,7 @@ pub struct StreamBuilder<'a, F> {
 
 impl<'a, F> StreamBuilder<'a, F> {
     pub fn new() -> StreamBuilder<'a, F> {
-        StreamBuilder {
-            name: None,
-            input: None,
-            output: None,
-            latency: None,
-            data_cb: None,
-            state_cb: None,
-            device_changed_cb: None,
-        }
+        Default::default()
     }
 
     pub fn data_callback<D>(&mut self, cb: D) -> &mut Self
@@ -219,6 +211,12 @@ impl<'a, F> StreamBuilder<'a, F> {
             stream.register_device_changed_callback(device_changed_callback)?;
         }
         Ok(Stream::new(stream))
+    }
+}
+
+impl<'a, F> Default for StreamBuilder<'a, F> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/cubeb-backend/src/capi.rs
+++ b/cubeb-backend/src/capi.rs
@@ -58,6 +58,12 @@ macro_rules! capi_new(
                 Some($crate::capi::capi_register_device_collection_changed::<$ctx>)
         }));
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `c` and `context` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_init<CTX: ContextOps>(
     c: *mut *mut ffi::cubeb,
     context_name: *const c_char,
@@ -71,11 +77,23 @@ pub unsafe extern "C" fn capi_init<CTX: ContextOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `c` pointer.
+/// The caller should ensure that pointer is valid.
 pub unsafe extern "C" fn capi_get_backend_id<CTX: ContextOps>(c: *mut ffi::cubeb) -> *const c_char {
     let ctx = &mut *(c as *mut CTX);
     ctx.backend_id().as_ptr()
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `c` and `max_channels` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_get_max_channel_count<CTX: ContextOps>(
     c: *mut ffi::cubeb,
     max_channels: *mut u32,
@@ -86,6 +104,12 @@ pub unsafe extern "C" fn capi_get_max_channel_count<CTX: ContextOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `c` and `latency_frames` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_get_min_latency<CTX: ContextOps>(
     c: *mut ffi::cubeb,
     param: ffi::cubeb_stream_params,
@@ -97,6 +121,12 @@ pub unsafe extern "C" fn capi_get_min_latency<CTX: ContextOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `c` and `rate` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_get_preferred_sample_rate<CTX: ContextOps>(
     c: *mut ffi::cubeb,
     rate: *mut u32,
@@ -107,6 +137,12 @@ pub unsafe extern "C" fn capi_get_preferred_sample_rate<CTX: ContextOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `c` and `collection` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_enumerate_devices<CTX: ContextOps>(
     c: *mut ffi::cubeb,
     devtype: ffi::cubeb_device_type,
@@ -119,6 +155,12 @@ pub unsafe extern "C" fn capi_enumerate_devices<CTX: ContextOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `c` and `collection` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_device_collection_destroy<CTX: ContextOps>(
     c: *mut ffi::cubeb,
     collection: *mut ffi::cubeb_device_collection,
@@ -129,10 +171,23 @@ pub unsafe extern "C" fn capi_device_collection_destroy<CTX: ContextOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `c` pointer.
+/// The caller should ensure that pointer is valid.
 pub unsafe extern "C" fn capi_destroy<CTX>(c: *mut ffi::cubeb) {
     let _: Box<CTX> = Box::from_raw(c as *mut _);
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `c`, `s`, `stream_name`, `input_stream_params`,
+/// `output_stream_params`, `data_callback`, `state_callback`, and `user_ptr` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_stream_init<CTX: ContextOps>(
     c: *mut ffi::cubeb,
     s: *mut *mut ffi::cubeb_stream,
@@ -169,10 +224,22 @@ pub unsafe extern "C" fn capi_stream_init<CTX: ContextOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s` pointer.
+/// The caller should ensure that pointer is valid.
 pub unsafe extern "C" fn capi_stream_destroy<STM>(s: *mut ffi::cubeb_stream) {
     let _ = Box::from_raw(s as *mut STM);
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s` pointer.
+/// The caller should ensure that pointer is valid.
 pub unsafe extern "C" fn capi_stream_start<STM: StreamOps>(s: *mut ffi::cubeb_stream) -> c_int {
     let stm = &mut *(s as *mut STM);
 
@@ -180,6 +247,12 @@ pub unsafe extern "C" fn capi_stream_start<STM: StreamOps>(s: *mut ffi::cubeb_st
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s` pointer.
+/// The caller should ensure that pointer is valid.
 pub unsafe extern "C" fn capi_stream_stop<STM: StreamOps>(s: *mut ffi::cubeb_stream) -> c_int {
     let stm = &mut *(s as *mut STM);
 
@@ -187,6 +260,12 @@ pub unsafe extern "C" fn capi_stream_stop<STM: StreamOps>(s: *mut ffi::cubeb_str
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s` and `position` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_stream_get_position<STM: StreamOps>(
     s: *mut ffi::cubeb_stream,
     position: *mut u64,
@@ -197,6 +276,12 @@ pub unsafe extern "C" fn capi_stream_get_position<STM: StreamOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s` and `latency` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_stream_get_latency<STM: StreamOps>(
     s: *mut ffi::cubeb_stream,
     latency: *mut u32,
@@ -207,6 +292,12 @@ pub unsafe extern "C" fn capi_stream_get_latency<STM: StreamOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s` and `latency` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_stream_get_input_latency<STM: StreamOps>(
     s: *mut ffi::cubeb_stream,
     latency: *mut u32,
@@ -217,6 +308,12 @@ pub unsafe extern "C" fn capi_stream_get_input_latency<STM: StreamOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s` pointer.
+/// The caller should ensure that pointer is valid.
 pub unsafe extern "C" fn capi_stream_set_volume<STM: StreamOps>(
     s: *mut ffi::cubeb_stream,
     volume: f32,
@@ -227,6 +324,12 @@ pub unsafe extern "C" fn capi_stream_set_volume<STM: StreamOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s` and `name` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_stream_set_name<STM: StreamOps>(
     s: *mut ffi::cubeb_stream,
     name: *const c_char,
@@ -241,6 +344,12 @@ pub unsafe extern "C" fn capi_stream_set_name<STM: StreamOps>(
     }
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s` and `device` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_stream_get_current_device<STM: StreamOps>(
     s: *mut ffi::cubeb_stream,
     device: *mut *mut ffi::cubeb_device,
@@ -251,6 +360,12 @@ pub unsafe extern "C" fn capi_stream_get_current_device<STM: StreamOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s` and `device` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_stream_device_destroy<STM: StreamOps>(
     s: *mut ffi::cubeb_stream,
     device: *mut ffi::cubeb_device,
@@ -261,6 +376,12 @@ pub unsafe extern "C" fn capi_stream_device_destroy<STM: StreamOps>(
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s` and `device_changed_callback` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_stream_register_device_changed_callback<STM: StreamOps>(
     s: *mut ffi::cubeb_stream,
     device_changed_callback: ffi::cubeb_device_changed_callback,
@@ -271,6 +392,13 @@ pub unsafe extern "C" fn capi_stream_register_device_changed_callback<STM: Strea
     ffi::CUBEB_OK
 }
 
+/// # Safety
+///
+/// Entry point from C code.
+///
+/// This function is unsafe because it dereferences the given `s`, `collection_changed_callback`, and
+/// `user_ptr` pointers.
+/// The caller should ensure those pointers are valid.
 pub unsafe extern "C" fn capi_register_device_collection_changed<CTX: ContextOps>(
     c: *mut ffi::cubeb,
     devtype: ffi::cubeb_device_type,

--- a/cubeb-backend/src/ops.rs
+++ b/cubeb-backend/src/ops.rs
@@ -39,6 +39,7 @@ pub struct Ops {
         ) -> c_int,
     >,
     pub destroy: Option<unsafe extern "C" fn(context: *mut ffi::cubeb)>,
+    #[allow(clippy::type_complexity)]
     pub stream_init: Option<
         unsafe extern "C" fn(
             context: *mut ffi::cubeb,

--- a/cubeb-core/src/builders.rs
+++ b/cubeb-core/src/builders.rs
@@ -12,9 +12,10 @@ pub struct StreamParamsBuilder(ffi::cubeb_stream_params);
 
 impl Default for StreamParamsBuilder {
     fn default() -> Self {
-        let mut r = ffi::cubeb_stream_params::default();
-        r.format = ffi::CUBEB_SAMPLE_S16NE;
-        StreamParamsBuilder(r)
+        StreamParamsBuilder(ffi::cubeb_stream_params {
+            format: ffi::CUBEB_SAMPLE_S16NE,
+            ..Default::default()
+        })
     }
 }
 

--- a/cubeb-core/src/channel.rs
+++ b/cubeb-core/src/channel.rs
@@ -67,9 +67,9 @@ impl From<ffi::cubeb_channel> for ChannelLayout {
     }
 }
 
-impl Into<ffi::cubeb_channel> for ChannelLayout {
-    fn into(self) -> ffi::cubeb_channel {
-        self.bits()
+impl From<ChannelLayout> for ffi::cubeb_channel {
+    fn from(x: ChannelLayout) -> Self {
+        x.bits()
     }
 }
 

--- a/cubeb-core/src/context.rs
+++ b/cubeb-core/src/context.rs
@@ -78,6 +78,10 @@ impl ContextRef {
         Ok(rate)
     }
 
+    /// # Safety
+    ///
+    /// This function is unsafe because it dereferences the given `data_callback`, `state_callback`, and `user_ptr` pointers.
+    /// The caller should ensure those pointers are valid.
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))]
     pub unsafe fn stream_init(
         &self,
@@ -125,6 +129,10 @@ impl ContextRef {
         Ok(DeviceCollection::init_with_ctx(self, coll))
     }
 
+    /// # Safety
+    ///
+    /// This function is unsafe because it dereferences the given `callback` and  `user_ptr` pointers.
+    /// The caller should ensure those pointers are valid.
     pub unsafe fn register_device_collection_changed(
         &self,
         devtype: DeviceType,

--- a/cubeb-core/src/device_collection.rs
+++ b/cubeb-core/src/device_collection.rs
@@ -55,11 +55,19 @@ impl<'ctx> ::std::convert::AsRef<DeviceCollectionRef> for DeviceCollection<'ctx>
 pub struct DeviceCollectionRef(ffi_types::Opaque);
 
 impl DeviceCollectionRef {
+    /// # Safety
+    ///
+    /// This function is unsafe because it dereferences the given `ptr` pointer.
+    /// The caller should ensure that pointer is valid.
     #[inline]
     pub unsafe fn from_ptr<'a>(ptr: *mut CType) -> &'a Self {
         &*(ptr as *mut _)
     }
 
+    /// # Safety
+    ///
+    /// This function is unsafe because it dereferences the given `ptr` pointer.
+    /// The caller should ensure that pointer is valid.
     #[inline]
     pub unsafe fn from_ptr_mut<'a>(ptr: *mut CType) -> &'a mut Self {
         &mut *(ptr as *mut _)

--- a/cubeb-core/src/error.rs
+++ b/cubeb-core/src/error.rs
@@ -52,7 +52,7 @@ impl Error {
         }
     }
 
-    pub unsafe fn from_raw(code: c_int) -> Error {
+    pub fn from_raw(code: c_int) -> Error {
         let code = match code {
             ffi::CUBEB_ERROR_INVALID_FORMAT => ErrorCode::InvalidFormat,
             ffi::CUBEB_ERROR_INVALID_PARAMETER => ErrorCode::InvalidParameter,
@@ -112,7 +112,7 @@ impl From<ErrorCode> for Error {
 
 impl From<NulError> for Error {
     fn from(_: NulError) -> Error {
-        unsafe { Error::from_raw(ffi::CUBEB_ERROR) }
+        Error::from_raw(ffi::CUBEB_ERROR)
     }
 }
 
@@ -126,7 +126,7 @@ mod tests {
         macro_rules! test {
             ( $($raw:ident => $err:ident),* ) => {{
                 $(
-                    let e = unsafe { Error::from_raw(ffi::$raw) };
+                    let e = Error::from_raw(ffi::$raw);
                     assert_eq!(e.raw_code(), ffi::$raw);
                     assert_eq!(e.code(), ErrorCode::$err);
                 )*

--- a/cubeb-core/src/error.rs
+++ b/cubeb-core/src/error.rs
@@ -26,6 +26,10 @@ pub struct Error {
 }
 
 impl Error {
+    // `clippy::self_named_constructor` is a nightly-only lint as of 2021-07-22,
+    // so we allow `unknown_lints` to ignore it on stable.
+    #[allow(unknown_lints)]
+    #[allow(clippy::self_named_constructor)]
     pub fn error() -> Self {
         Error {
             code: ErrorCode::Error,

--- a/cubeb-core/src/ffi_types.rs
+++ b/cubeb-core/src/ffi_types.rs
@@ -23,6 +23,10 @@ macro_rules! ffi_type_heap {
         pub struct $owned(*mut $ctype);
 
         impl $owned {
+            /// # Safety
+            ///
+            /// This function is unsafe because it dereferences the given `ptr` pointer.
+            /// The caller should ensure that pointer is valid.
             #[inline]
             pub unsafe fn from_ptr(ptr: *mut $ctype) -> $owned {
                 $owned(ptr)
@@ -100,11 +104,19 @@ macro_rules! ffi_type_heap {
         pub struct $borrowed($crate::ffi_types::Opaque);
 
         impl $borrowed {
+            /// # Safety
+            ///
+            /// This function is unsafe because it dereferences the given `ptr` pointer.
+            /// The caller should ensure that pointer is valid.
             #[inline]
             pub unsafe fn from_ptr<'a>(ptr: *mut $ctype) -> &'a Self {
                 &*(ptr as *mut _)
             }
 
+            /// # Safety
+            ///
+            /// This function is unsafe because it dereferences the given `ptr` pointer.
+            /// The caller should ensure that pointer is valid.
             #[inline]
             pub unsafe fn from_ptr_mut<'a>(ptr: *mut $ctype) -> &'a mut Self {
                 &mut *(ptr as *mut _)
@@ -194,11 +206,19 @@ macro_rules! ffi_type_stack {
         pub struct $borrowed($crate::ffi_types::Opaque);
 
         impl $borrowed {
+            /// # Safety
+            ///
+            /// This function is unsafe because it dereferences the given `ptr` pointer.
+            /// The caller should ensure that pointer is valid.
             #[inline]
             pub unsafe fn from_ptr<'a>(ptr: *mut $ctype) -> &'a Self {
                 &*(ptr as *mut _)
             }
 
+            /// # Safety
+            ///
+            /// This function is unsafe because it dereferences the given `ptr` pointer.
+            /// The caller should ensure that pointer is valid.
             #[inline]
             pub unsafe fn from_ptr_mut<'a>(ptr: *mut $ctype) -> &'a mut Self {
                 &mut *(ptr as *mut _)

--- a/cubeb-core/src/format.rs
+++ b/cubeb-core/src/format.rs
@@ -29,11 +29,10 @@ impl From<ffi::cubeb_sample_format> for SampleFormat {
     }
 }
 
-impl Into<ffi::cubeb_sample_format> for SampleFormat {
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::match_same_arms))]
-    fn into(self) -> ffi::cubeb_sample_format {
+impl From<SampleFormat> for ffi::cubeb_sample_format {
+    fn from(x: SampleFormat) -> Self {
         use SampleFormat::*;
-        match self {
+        match x {
             S16LE => ffi::CUBEB_SAMPLE_S16LE,
             S16BE => ffi::CUBEB_SAMPLE_S16BE,
             Float32LE => ffi::CUBEB_SAMPLE_FLOAT32LE,

--- a/cubeb-core/src/stream.rs
+++ b/cubeb-core/src/stream.rs
@@ -34,10 +34,10 @@ impl From<ffi::cubeb_state> for State {
     }
 }
 
-impl Into<ffi::cubeb_state> for State {
-    fn into(self) -> ffi::cubeb_state {
+impl From<State> for ffi::cubeb_state {
+    fn from(x: State) -> Self {
         use State::*;
-        match self {
+        match x {
             Started => ffi::CUBEB_STATE_STARTED,
             Stopped => ffi::CUBEB_STATE_STOPPED,
             Drained => ffi::CUBEB_STATE_DRAINED,

--- a/cubeb-core/src/try_call.rs
+++ b/cubeb-core/src/try_call.rs
@@ -9,7 +9,7 @@ use Error;
 
 pub fn cvt_r(ret: c_int) -> Result<(), Error> {
     match ret {
-        n if n < 0 => Err(unsafe { Error::from_raw(n) }),
+        n if n < 0 => Err(Error::from_raw(n)),
         _ => Ok(()),
     }
 }


### PR DESCRIPTION
`systest` is excluded from clippy on CI because it's [all generated code](https://github.com/mozilla/cubeb-rs/blob/master/systest/src/main.rs#L8).

Nightly build failure is due to https://github.com/mozilla/cubeb-rs/issues/56.