### PR TITLE
Fix infinite loop in StreamBuilder::new()/default()

### DIFF
--- a/cubeb-api/src/stream.rs
+++ b/cubeb-api/src/stream.rs
@@ -216,7 +216,15 @@ impl<'a, F> StreamBuilder<'a, F> {
 
 impl<'a, F> Default for StreamBuilder<'a, F> {
     fn default() -> Self {
-        Self::new()
+        StreamBuilder {
+            name: None,
+            input: None,
+            output: None,
+            latency: None,
+            data_cb: None,
+            state_cb: None,
+            device_changed_cb: None,
+        }
     }
 }
 


### PR DESCRIPTION
This bug was intruduced in [7c9c659](https://github.com/mozilla/cubeb-rs/commit/7c9c659479f794336c0b54e28ce148114d2b1537).