### PR TITLE
cubeb-core: Ignore clippy::self_named_constructors on `Error::error`.

### DIFF
--- a/cubeb-core/src/error.rs
+++ b/cubeb-core/src/error.rs
@@ -26,10 +26,7 @@ pub struct Error {
 }
 
 impl Error {
-    // `clippy::self_named_constructor` is a nightly-only lint as of 2021-07-22,
-    // so we allow `unknown_lints` to ignore it on stable.
-    #[allow(unknown_lints)]
-    #[allow(clippy::self_named_constructor)]
+    #[allow(clippy::self_named_constructors)]
     pub fn error() -> Self {
         Error {
             code: ErrorCode::Error,


### PR DESCRIPTION
Clippy's `self_named_constructor` warning was renamed to `self_named_constructors` before it hit stable.