### PR TITLE
Reflect resampler ABI change, bump version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,3 @@ jobs:
       shell: bash
       run: rustup run ${{ matrix.rust }} cargo test --all
 
-    - name: Run systest
-      shell: bash
-      run: rustup run ${{ matrix.rust }} cargo run -p systest
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "cubeb-api",
     "cubeb-backend",
     "cubeb-sys",
-    "systest"
+    # Re-enable when https://github.com/mozilla/cubeb-rs/issues/63 is sorted out
+    # "systest",
 ]


### PR DESCRIPTION
`libcubeb` changes in https://github.com/mozilla/cubeb/pull/690

This will need a change to the submodule in `cubeb-sys` probably?