### PR TITLE
Reflect resampler ABI change, bump version (fixups)

### DIFF
--- a/cubeb-api/Cargo.toml
+++ b/cubeb-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 readme = "README.md"
@@ -19,4 +19,4 @@ circle-ci = { repository = "djg/cubeb-rs" }
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
 
 [dependencies]
-cubeb-core = { path = "../cubeb-core", version = "0.9.0" }
+cubeb-core = { path = "../cubeb-core", version = "0.10.0" }

--- a/cubeb-backend/Cargo.toml
+++ b/cubeb-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-backend"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]
@@ -18,4 +18,4 @@ circle-ci = { repository = "djg/cubeb-rs" }
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
 
 [dependencies]
-cubeb-core = { path = "../cubeb-core", version = "0.9.0" }
+cubeb-core = { path = "../cubeb-core", version = "0.10.0" }

--- a/cubeb-core/Cargo.toml
+++ b/cubeb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-core"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]
@@ -19,4 +19,4 @@ gecko-in-tree = ["cubeb-sys/gecko-in-tree"]
 
 [dependencies]
 bitflags = "1.2.0"
-cubeb-sys = { path = "../cubeb-sys", version = "0.9.0" }
+cubeb-sys = { path = "../cubeb-sys", version = "0.10.0" }

--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-sys"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 repository = "https://github.com/djg/cubeb-rs"
 license = "ISC"

--- a/cubeb-sys/src/resampler.rs
+++ b/cubeb-sys/src/resampler.rs
@@ -17,6 +17,13 @@ cubeb_enum! {
     }
 }
 
+cubeb_enum! {
+    pub enum cubeb_resampler_reclock {
+        CUBEB_RESAMPLER_RECLOCK_NONE,
+        CUBEB_RESAMPLER_RECLOCK_INPUT,
+    }
+}
+
 extern "C" {
     pub fn cubeb_resampler_create(
         stream: *mut cubeb_stream,
@@ -26,6 +33,7 @@ extern "C" {
         callback: cubeb_data_callback,
         user_ptr: *mut c_void,
         quality: cubeb_resampler_quality,
+        reclock: cubeb_resampler_reclock,
     ) -> *mut cubeb_resampler;
 
     pub fn cubeb_resampler_fill(


### PR DESCRIPTION
Commits missed in #62 because of a bad rebase.