### PR TITLE
Pass architecture as a CMake parameter on macOS

### DIFF
--- a/cubeb-sys/build.rs
+++ b/cubeb-sys/build.rs
@@ -43,6 +43,17 @@ fn main() {
     let freebsd = target.contains("freebsd");
     let mut cfg = cmake::Config::new("libcubeb");
 
+    if darwin {
+        let cmake_osx_arch = if target.contains("aarch64") {
+            // Apple Silicon
+            "arm64"
+        } else {
+            // Assuming Intel (x86_64)
+            "x86_64"
+        };
+        cfg.define("CMAKE_OSX_ARCHITECTURES", cmake_osx_arch);
+    }
+
     let _ = fs::remove_dir_all(env::var("OUT_DIR").unwrap());
     t!(fs::create_dir_all(env::var("OUT_DIR").unwrap()));
 


### PR DESCRIPTION
This is to make it possible to cross-compile on macOS.

Before the change, on an Apple Silicon Mac, calling `cargo build --target=x86_64-apple-darwin` fails to produce binaries for the corresponding architecture. 