### PR TITLE
Relax constraints on callbacks by dropping Sync requirement

### DIFF
--- a/cubeb-api/src/stream.rs
+++ b/cubeb-api/src/stream.rs
@@ -68,9 +68,9 @@ use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::{ops, panic, ptr};
 use {ContextRef, DeviceId, Error, Result, State, StreamParamsRef};
 
-pub type DataCallback<F> = dyn FnMut(&[F], &mut [F]) -> isize + Send + Sync + 'static;
-pub type StateCallback = dyn FnMut(State) + Send + Sync + 'static;
-pub type DeviceChangedCallback = dyn FnMut() + Send + Sync + 'static;
+pub type DataCallback<F> = dyn FnMut(&[F], &mut [F]) -> isize + Send + 'static;
+pub type StateCallback = dyn FnMut(State) + Send + 'static;
+pub type DeviceChangedCallback = dyn FnMut() + Send + 'static;
 
 pub struct StreamCallbacks<F> {
     pub(crate) data: Box<DataCallback<F>>,
@@ -119,14 +119,14 @@ impl<'a, F> StreamBuilder<'a, F> {
 
     pub fn data_callback<D>(&mut self, cb: D) -> &mut Self
     where
-        D: FnMut(&[F], &mut [F]) -> isize + Send + Sync + 'static,
+        D: FnMut(&[F], &mut [F]) -> isize + Send + 'static,
     {
         self.data_cb = Some(Box::new(cb) as Box<DataCallback<F>>);
         self
     }
     pub fn state_callback<S>(&mut self, cb: S) -> &mut Self
     where
-        S: FnMut(State) + Send + Sync + 'static,
+        S: FnMut(State) + Send + 'static,
     {
         self.state_cb = Some(Box::new(cb) as Box<StateCallback>);
         self
@@ -164,7 +164,7 @@ impl<'a, F> StreamBuilder<'a, F> {
 
     pub fn device_changed_cb<CB>(&mut self, cb: CB) -> &mut Self
     where
-        CB: FnMut() + Send + Sync + 'static,
+        CB: FnMut() + Send + 'static,
     {
         self.device_changed_cb = Some(Box::new(cb) as Box<DeviceChangedCallback>);
         self

--- a/cubeb-backend/tests/test_capi.rs
+++ b/cubeb-backend/tests/test_capi.rs
@@ -19,6 +19,7 @@ use std::ptr;
 pub const OPS: Ops = capi_new!(TestContext, TestStream);
 
 struct TestContext {
+    #[allow(dead_code)]
     pub ops: *const Ops,
 }
 


### PR DESCRIPTION
A cubeb backend may run user callbacks on any thread it chooses to, but must never run the same user callback on multiple threads concurrently. If I understand correctly, the `Send` constraint is sufficient to represent the appropriate constraint for this, making `Sync` unnecessary.

Fixes https://github.com/mozilla/cubeb-rs/issues/68