### PR TITLE
Expose async logging for backends

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cubeb-sys/libcubeb"]
 	path = cubeb-sys/libcubeb
-	url = https://github.com/kinetiknz/cubeb
+	url = https://github.com/mozilla/cubeb

--- a/cubeb-api/Cargo.toml
+++ b/cubeb-api/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "cubeb"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 readme = "README.md"
 keywords = ["cubeb"]
-repository = "https://github.com/djg/cubeb-rs"
-homepage = "https://github.com/djg/cubeb-rs"
+repository = "https://github.com/mozilla/cubeb-rs"
+homepage = "https://github.com/mozilla/cubeb-rs"
 description = """
 Bindings to libcubeb for interacting with system audio from rust.
 """
 categories = ["api-bindings"]
 
 [badges]
-circle-ci = { repository = "djg/cubeb-rs" }
+circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
 
 [dependencies]
-cubeb-core = { path = "../cubeb-core", version = "0.10.0" }
+cubeb-core = { path = "../cubeb-core", version = "0.10.1" }

--- a/cubeb-backend/Cargo.toml
+++ b/cubeb-backend/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "cubeb-backend"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]
-repository = "https://github.com/djg/cubeb-rs"
-homepage = "https://github.com/djg/cubeb-rs"
+repository = "https://github.com/mozilla/cubeb-rs"
+homepage = "https://github.com/mozilla/cubeb-rs"
 description = """
 Bindings to libcubeb internals to facilitate implementing cubeb backends in rust.
 """
 categories = ["api-bindings"]
 
 [badges]
-circle-ci = { repository = "djg/cubeb-rs" }
+circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
 
 [dependencies]
-cubeb-core = { path = "../cubeb-core", version = "0.10.0" }
+cubeb-core = { path = "../cubeb-core", version = "0.10.1" }

--- a/cubeb-backend/src/lib.rs
+++ b/cubeb-backend/src/lib.rs
@@ -7,7 +7,7 @@ extern crate cubeb_core;
 
 pub mod capi;
 #[macro_use]
-mod log;
+pub mod log;
 mod ops;
 mod traits;
 

--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -5,69 +5,100 @@
 
 #[macro_export]
 macro_rules! cubeb_log_internal {
-    ($level: expr, $msg: expr) => {
+    ($use_async: ident, $level: expr, $msg: expr) => {
         #[allow(unused_unsafe)]
         unsafe {
             if $level <= $crate::ffi::g_cubeb_log_level.into() {
-                cubeb_log_internal!(__INTERNAL__ $msg);
+                cubeb_log_internal!($use_async, __INTERNAL__ $msg);
             }
         }
     };
-    ($level: expr, $fmt: expr, $($arg: expr),+) => {
+    ($use_async: ident, $level: expr, $fmt: expr, $($arg: expr),+) => {
         #[allow(unused_unsafe)]
         unsafe {
             if $level <= $crate::ffi::g_cubeb_log_level.into() {
-                cubeb_log_internal!(__INTERNAL__ format!($fmt, $($arg),*));
+                cubeb_log_internal!($use_async, __INTERNAL__ format!($fmt, $($arg),*));
             }
         }
     };
-    (__INTERNAL__ $msg: expr) => {
-        if let Some(log_callback) = $crate::ffi::g_cubeb_log_callback {
-            use std::io::Write;
+    ($use_async: ident, __INTERNAL__ $msg: expr) => {
+        use std::io::Write;
+        let mut buf = [0 as u8; 1024];
+        let filename = std::path::Path::new(file!())
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
+        // 2 for ':', 1 for ' ', 1 for '\n', and 1 for converting `line!()` to number of digits
+        let len = filename.len() + ((line!() as f32).log10().trunc() as usize) + $msg.len() + 5;
+        debug_assert!(len < buf.len(), "log will be truncated");
+        let _ = write!(&mut buf[..], "{}:{}: {}\n", filename, line!(), $msg);
+        let last = std::cmp::min(len, buf.len() - 1);
+        buf[last] = 0;
+        let cstr = unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(&buf[..=last]) };
 
-            let mut buf = [0 as u8; 1024];
-            let filename = std::path::Path::new(file!())
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap();
-            // 2 for ':', 1 for ' ', 1 for '\n', and 1 for converting `line!()` to number of digits
-            let len = filename.len() + ((line!() as f32).log10().trunc() as usize) + $msg.len() + 5;
-            debug_assert!(len < buf.len(), "log will be truncated");
-            let _ = write!(&mut buf[..], "{}:{}: {}\n", filename, line!(), $msg);
-            let last = std::cmp::min(len, buf.len() - 1);
-            buf[last] = 0;
-            let cstr = unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(&buf[..=last]) };
-            log_callback(cstr.as_ptr());
+        match($use_async) {
+            false => {
+                if let Some(log_callback) = $crate::ffi::g_cubeb_log_callback {
+                    log_callback(cstr.as_ptr());
+                }
+            }
+            true => { $crate::ffi::cubeb_async_log(cstr.as_ptr()); }
         }
     }
 }
 
 #[macro_export]
 macro_rules! cubeb_logv {
-    ($msg: expr) => (cubeb_log_internal!($crate::LogLevel::Verbose, $msg));
-    ($fmt: expr, $($arg: expr),+) => (cubeb_log_internal!($crate::LogLevel::Verbose, $fmt, $($arg),*));
+    ($msg: expr) => (cubeb_log_internal!(false, $crate::LogLevel::Verbose, $msg));
+    ($fmt: expr, $($arg: expr),+) => (cubeb_log_internal!(false, $crate::LogLevel::Verbose, $fmt, $($arg),*));
 }
 
 #[macro_export]
 macro_rules! cubeb_log {
-    ($msg: expr) => (cubeb_log_internal!($crate::LogLevel::Normal, $msg));
-    ($fmt: expr, $($arg: expr),+) => (cubeb_log_internal!($crate::LogLevel::Normal, $fmt, $($arg),*));
+    ($msg: expr) => (cubeb_log_internal!(false, $crate::LogLevel::Normal, $msg));
+    ($fmt: expr, $($arg: expr),+) => (cubeb_log_internal!(false, $crate::LogLevel::Normal, $fmt, $($arg),*));
+}
+
+#[macro_export]
+macro_rules! cubeb_alogv {
+    ($msg: expr) => (cubeb_log_internal!(true, $crate::LogLevel::Verbose, $msg));
+    ($fmt: expr, $($arg: expr),+) => (cubeb_log_internal!(true, $crate::LogLevel::Verbose, $fmt, $($arg),*));
+}
+
+#[macro_export]
+macro_rules! cubeb_alog {
+    ($msg: expr) => (cubeb_log_internal!(true, $crate::LogLevel::Normal, $msg));
+    ($fmt: expr, $($arg: expr),+) => (cubeb_log_internal!(true, $crate::LogLevel::Verbose, $fmt, $($arg),*));
 }
 
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test_normal_logging() {
-        cubeb_log!("This is log at normal level");
+    fn test_normal_logging_sync() {
+        cubeb_log!("This is synchronous log output at normal level");
         cubeb_log!("{} Formatted log", 1);
         cubeb_log!("{} Formatted {} log {}", 1, 2, 3);
     }
 
     #[test]
-    fn test_verbose_logging() {
-        cubeb_logv!("This is a log at verbose level");
+    fn test_verbose_logging_sync() {
+        cubeb_logv!("This is synchronous log output at verbose level");
         cubeb_logv!("{} Formatted log", 1);
         cubeb_logv!("{} Formatted {} log {}", 1, 2, 3);
+    }
+
+    #[test]
+    fn test_normal_logging_async() {
+        cubeb_alog!("This is asynchronous log output at normal level");
+        cubeb_alog!("{} Formatted log", 1);
+        cubeb_alog!("{} Formatted {} log {}", 1, 2, 3);
+    }
+
+    #[test]
+    fn test_verbose_logging_async() {
+        cubeb_alogv!("This is asynchronous log output at verbose level");
+        cubeb_alogv!("{} Formatted log", 1);
+        cubeb_alogv!("{} Formatted {} log {}", 1, 2, 3);
     }
 }

--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -20,7 +20,7 @@ pub fn cubeb_log_internal_buf_fmt<'a>(
     // 2 for ':', 1 for ' ', 1 for '\n', and 1 for converting `line!()` to number of digits
     let len = filename.len() + ((line as f32).log10().trunc() as usize) + msg.len() + 5 + 5;
     debug_assert!(len < buf.len(), "log will be truncated");
-    let _ = write!(&mut buf[..], "{}:{}: {}\n", filename, line, msg);
+    let _ = writeln!(&mut buf[..], "{}:{}: {}\n", filename, line, msg);
     let last = std::cmp::min(len, buf.len() - 1);
     buf[last] = 0;
     let cstr = unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(&buf[..=last]) };

--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -18,7 +18,7 @@ pub fn cubeb_log_internal_buf_fmt<'a>(
         .to_str()
         .unwrap();
     // 2 for ':', 1 for ' ', 1 for '\n', and 1 for converting `line!()` to number of digits
-    let len = filename.len() + ((line as f32).log10().trunc() as usize) + msg.len() + 5 + 5;
+    let len = filename.len() + ((line as f32).log10().trunc() as usize) + msg.len() + 5;
     debug_assert!(len < buf.len(), "log will be truncated");
     let _ = writeln!(&mut buf[..], "{}:{}: {}", filename, line, msg);
     let last = std::cmp::min(len, buf.len() - 1);

--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -5,7 +5,12 @@
 
 /// Annotates input buffer string with logging information.
 /// Returns result as a ffi::CStr for use with native cubeb logging functions.
-pub fn cubeb_log_internal_buf_fmt<'a>(buf: &'a mut [u8; 1024], file: &str, line: u32, msg: &str) -> &'a std::ffi::CStr {
+pub fn cubeb_log_internal_buf_fmt<'a>(
+    buf: &'a mut [u8; 1024],
+    file: &str,
+    line: u32,
+    msg: &str,
+) -> &'a std::ffi::CStr {
     use std::io::Write;
     let filename = std::path::Path::new(file)
         .file_name()

--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -3,7 +3,6 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-
 #[macro_export]
 macro_rules! cubeb_log_internal {
     ($use_async: ident, $level: expr, $msg: expr) => {

--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -3,81 +3,64 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-#[macro_export]
-macro_rules! cubeb_log_internal {
-    ($use_async: ident, $level: expr, $msg: expr) => {
-        #[allow(unused_unsafe)]
-        unsafe {
-            if $level <= $crate::ffi::g_cubeb_log_level.into() {
-                cubeb_log_internal!($use_async, __INTERNAL__ $msg);
-            }
-        }
-    };
-    ($use_async: ident, $level: expr, $fmt: expr, $($arg: expr),+) => {
-        #[allow(unused_unsafe)]
-        unsafe {
-            if $level <= $crate::ffi::g_cubeb_log_level.into() {
-                cubeb_log_internal!($use_async, __INTERNAL__ format!($fmt, $($arg),*));
-            }
-        }
-    };
-    ($use_async: ident, __INTERNAL__ $msg: expr) => {
-        fn get_cstr<'a>(buf: &'a mut [u8; 1024], file: &str, line: u32, msg: &str) -> &'a std::ffi::CStr {
-            use std::io::Write;
-            let filename = std::path::Path::new(file)
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap();
-            // 2 for ':', 1 for ' ', 1 for '\n', and 1 for converting `line!()` to number of digits
-            let len = filename.len() + ((line as f32).log10().trunc() as usize) + msg.len() + 5 + 5;
-            debug_assert!(len < buf.len(), "log will be truncated");
-            let _ = write!(&mut buf[..], "{}:{}: {}\n", filename, line, msg);
-            let last = std::cmp::min(len, buf.len() - 1);
-            buf[last] = 0;
-            let cstr = unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(&buf[..=last]) };
-            cstr
-        }
-
-        match($use_async) {
-            false => {
-                if let Some(log_callback) = $crate::ffi::g_cubeb_log_callback {
-                    let mut buf = [0u8; 1024];
-                    log_callback(get_cstr(&mut buf, file!(), line!(), &$msg).as_ptr());
-                }
-            }
-            true => {
-                {   // Extra braces here to limit buf's lifetime
-                    let mut buf = [0u8; 1024];
-                    $crate::ffi::cubeb_async_log(get_cstr(&mut buf, file!(), line!(), &$msg).as_ptr());
-                }
-            }
-        }
-    }
+/// Annotates input buffer string with logging information.
+/// Returns result as a ffi::CStr for use with native cubeb logging functions.
+pub fn cubeb_log_internal_buf_fmt<'a>(buf: &'a mut [u8; 1024], file: &str, line: u32, msg: &str) -> &'a std::ffi::CStr {
+    use std::io::Write;
+    let filename = std::path::Path::new(file)
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap();
+    // 2 for ':', 1 for ' ', 1 for '\n', and 1 for converting `line!()` to number of digits
+    let len = filename.len() + ((line as f32).log10().trunc() as usize) + msg.len() + 5 + 5;
+    debug_assert!(len < buf.len(), "log will be truncated");
+    let _ = write!(&mut buf[..], "{}:{}: {}\n", filename, line, msg);
+    let last = std::cmp::min(len, buf.len() - 1);
+    buf[last] = 0;
+    let cstr = unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(&buf[..=last]) };
+    cstr
 }
 
 #[macro_export]
-macro_rules! cubeb_logv {
-    ($msg: expr) => (cubeb_log_internal!(false, $crate::LogLevel::Verbose, $msg));
-    ($fmt: expr, $($arg: expr),+) => (cubeb_log_internal!(false, $crate::LogLevel::Verbose, $fmt, $($arg),*));
+macro_rules! cubeb_log_internal {
+    ($log_callback: expr, $level: expr, $fmt: expr, $($arg: expr),+) => {
+        cubeb_log_internal!($log_callback, $level, format!($fmt, $($arg),*));
+    };
+    ($log_callback: expr, $level: expr, $msg: expr) => {
+        #[allow(unused_unsafe)]
+        unsafe {
+            if $level <= $crate::ffi::g_cubeb_log_level.into() {
+                if let Some(log_callback) = $log_callback {
+                    let mut buf = [0u8; 1024];
+                    log_callback(
+                        $crate::log::cubeb_log_internal_buf_fmt(&mut buf, file!(), line!(), &$msg)
+                            .as_ptr(),
+                    );
+                }
+            }
+        }
+    };
 }
 
 #[macro_export]
 macro_rules! cubeb_log {
-    ($msg: expr) => (cubeb_log_internal!(false, $crate::LogLevel::Normal, $msg));
-    ($fmt: expr, $($arg: expr),+) => (cubeb_log_internal!(false, $crate::LogLevel::Normal, $fmt, $($arg),*));
+    ($($arg: expr),+) => (cubeb_log_internal!($crate::ffi::g_cubeb_log_callback, $crate::LogLevel::Normal, $($arg),+));
 }
 
 #[macro_export]
-macro_rules! cubeb_alogv {
-    ($msg: expr) => (cubeb_log_internal!(true, $crate::LogLevel::Verbose, $msg));
-    ($fmt: expr, $($arg: expr),+) => (cubeb_log_internal!(true, $crate::LogLevel::Verbose, $fmt, $($arg),*));
+macro_rules! cubeb_logv {
+    ($($arg: expr),+) => (cubeb_log_internal!($crate::ffi::g_cubeb_log_callback, $crate::LogLevel::Verbose, $($arg),+));
 }
 
 #[macro_export]
 macro_rules! cubeb_alog {
-    ($msg: expr) => (cubeb_log_internal!(true, $crate::LogLevel::Normal, $msg));
-    ($fmt: expr, $($arg: expr),+) => (cubeb_log_internal!(true, $crate::LogLevel::Verbose, $fmt, $($arg),*));
+    ($($arg: expr),+) => (cubeb_log_internal!($crate::ffi::cubeb_async_log.into(), $crate::LogLevel::Normal, $($arg),+));
+}
+
+#[macro_export]
+macro_rules! cubeb_alogv {
+    ($($arg: expr),+) => (cubeb_log_internal!($crate::ffi::cubeb_async_log.into(), $crate::LogLevel::Verbose, $($arg),+));
 }
 
 #[cfg(test)]

--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -20,7 +20,7 @@ pub fn cubeb_log_internal_buf_fmt<'a>(
     // 2 for ':', 1 for ' ', 1 for '\n', and 1 for converting `line!()` to number of digits
     let len = filename.len() + ((line as f32).log10().trunc() as usize) + msg.len() + 5 + 5;
     debug_assert!(len < buf.len(), "log will be truncated");
-    let _ = writeln!(&mut buf[..], "{}:{}: {}\n", filename, line, msg);
+    let _ = writeln!(&mut buf[..], "{}:{}: {}", filename, line, msg);
     let last = std::cmp::min(len, buf.len() - 1);
     buf[last] = 0;
     let cstr = unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(&buf[..=last]) };

--- a/cubeb-core/Cargo.toml
+++ b/cubeb-core/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "cubeb-core"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 license = "ISC"
 keywords = ["cubeb"]
-repository = "https://github.com/djg/cubeb-rs"
-homepage = "https://github.com/djg/cubeb-rs"
+repository = "https://github.com/mozilla/cubeb-rs"
+homepage = "https://github.com/mozilla/cubeb-rs"
 description = """
 Common types and definitions for cubeb rust and C bindings. Not intended for direct use.
 """
 categories = ["api-bindings"]
 
 [badges]
-circle-ci = { repository = "djg/cubeb-rs" }
+circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-sys/gecko-in-tree"]
 
 [dependencies]
 bitflags = "1.2.0"
-cubeb-sys = { path = "../cubeb-sys", version = "0.10.0" }
+cubeb-sys = { path = "../cubeb-sys", version = "0.10.1" }

--- a/cubeb-core/src/log.rs
+++ b/cubeb-core/src/log.rs
@@ -31,7 +31,6 @@ pub fn log_enabled() -> bool {
     unsafe { ffi::g_cubeb_log_level != LogLevel::Disabled as _ }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cubeb-core/src/log.rs
+++ b/cubeb-core/src/log.rs
@@ -31,6 +31,7 @@ pub fn log_enabled() -> bool {
     unsafe { ffi::g_cubeb_log_level != LogLevel::Disabled as _ }
 }
 
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cubeb-sys"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
-repository = "https://github.com/djg/cubeb-rs"
+repository = "https://github.com/mozilla/cubeb-rs"
 license = "ISC"
 description = "Native bindings to the cubeb library"
 
@@ -10,7 +10,7 @@ links = "cubeb"
 build = "build.rs"
 
 [badges]
-circle-ci = { repository = "djg/cubeb-rs" }
+circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = []

--- a/cubeb-sys/build.rs
+++ b/cubeb-sys/build.rs
@@ -95,6 +95,7 @@ fn main() {
         let _ = pkg_config::find_library("alsa");
         let _ = pkg_config::find_library("libpulse");
         let _ = pkg_config::find_library("jack");
+        let _ = pkg_config::find_library("speexdsp");
         if android {
             println!("cargo:rustc-link-lib=dylib=OpenSLES");
         }

--- a/cubeb-sys/src/log.rs
+++ b/cubeb-sys/src/log.rs
@@ -24,6 +24,6 @@ extern "C" {
     pub static g_cubeb_log_level: cubeb_log_level;
     pub static g_cubeb_log_callback: cubeb_log_callback;
 
-    pub fn cubeb_async_log_reset_threads() -> c_void;
+    pub fn cubeb_async_log_reset_threads(_: c_void) -> c_void;
     pub fn cubeb_async_log(msg: *const c_char, ...) -> c_void;
 }

--- a/cubeb-sys/src/log.rs
+++ b/cubeb-sys/src/log.rs
@@ -3,7 +3,7 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use std::os::raw::{c_char, c_int};
+use std::os::raw::{c_char, c_int, c_void};
 
 cubeb_enum! {
     pub enum cubeb_log_level {
@@ -23,4 +23,7 @@ extern "C" {
 
     pub static g_cubeb_log_level: cubeb_log_level;
     pub static g_cubeb_log_callback: cubeb_log_callback;
+
+    pub fn cubeb_async_log_reset_threads() -> c_void;
+    pub fn cubeb_async_log(msg: *const c_char, ...) -> c_void;
 }

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -11,7 +11,8 @@ fn main() {
     // Include the header files where the C APIs are defined
     cfg.header("cubeb.h")
         .header("cubeb_mixer.h")
-        .header("cubeb_resampler.h");
+        .header("cubeb_resampler.h")
+        .header("cubeb_log.h");
 
     // Include the directory where the header files are defined
     cfg.include(root.join("include"))


### PR DESCRIPTION
Patch to expose async logging for backends. Adds `cubeb_alog!` / `cubeb_alogv!` macros to make use of it.