### PR TITLE
Fix deref which would be done by auto-deref error in nightly

### DIFF
--- a/cubeb-core/src/device_collection.rs
+++ b/cubeb-core/src/device_collection.rs
@@ -48,7 +48,7 @@ impl<'ctx> ::std::ops::Deref for DeviceCollection<'ctx> {
 impl<'ctx> ::std::convert::AsRef<DeviceCollectionRef> for DeviceCollection<'ctx> {
     #[inline]
     fn as_ref(&self) -> &DeviceCollectionRef {
-        &**self
+        self
     }
 }
 


### PR DESCRIPTION
Quick fix to make clippy happy. [(more info)](https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref)