### PR TITLE
Add more documentation to `cubeb-api`

### DIFF
--- a/cubeb-api/src/context.rs
+++ b/cubeb-api/src/context.rs
@@ -1,6 +1,7 @@
 use std::ffi::CString;
 use {Context, Result};
 
+/// Initialize a new cubeb [`Context`]
 pub fn init<T: Into<Vec<u8>>>(name: T) -> Result<Context> {
     let name = CString::new(name)?;
 

--- a/cubeb-api/src/lib.rs
+++ b/cubeb-api/src/lib.rs
@@ -10,6 +10,8 @@
 //! expose the internal interfaces, so isn't suitable for extending
 //! libcubeb. See [cubeb-pulse-rs][2] for an example of extending
 //! libcubeb via implementing a cubeb backend in rust.
+//!
+//! To get started, have a look at the [`StreamBuilder`]
 
 // Copyright © 2017-2018 Mozilla Foundation
 //


### PR DESCRIPTION
Over at https://github.com/orottier/web-audio-api-rs/pull/186 we're adding support for `cubeb`.
I noticed the rust bindings are not documented very extensively, so I made a small start for the `cubeb-api` crate.
If this is something you are willing to merge, I could do the same for `cubeb-core`.
Most of the doc strings are taken from https://github.com/mozilla/cubeb/blob/master/include/cubeb/cubeb.h