### PR TITLE
Update cubeb-rs for internal logging ABI changes.

### DIFF
--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -77,7 +77,7 @@ macro_rules! cubeb_log_internal {
     ($log_callback: expr, $level: expr, $fmt: expr, $($arg: expr),+) => {
         #[allow(unused_unsafe)]
         unsafe {
-            if $level <= $crate::ffi::g_cubeb_log_level.into() {
+            if $level <= $crate::ffi::cubeb_log_get_level().into() {
                 if let Some(log_callback) = $log_callback {
                     $crate::log::cubeb_log_internal_buf_fmt(log_callback, file!(), line!(), format_args!($fmt, $($arg),+));
                 }

--- a/cubeb-backend/src/log.rs
+++ b/cubeb-backend/src/log.rs
@@ -91,12 +91,12 @@ macro_rules! cubeb_log_internal {
 
 #[macro_export]
 macro_rules! cubeb_log {
-    ($($arg: expr),+) => (cubeb_log_internal!($crate::ffi::g_cubeb_log_callback, $crate::LogLevel::Normal, $($arg),+));
+    ($($arg: expr),+) => (cubeb_log_internal!($crate::ffi::cubeb_log_get_callback(), $crate::LogLevel::Normal, $($arg),+));
 }
 
 #[macro_export]
 macro_rules! cubeb_logv {
-    ($($arg: expr),+) => (cubeb_log_internal!($crate::ffi::g_cubeb_log_callback, $crate::LogLevel::Verbose, $($arg),+));
+    ($($arg: expr),+) => (cubeb_log_internal!($crate::ffi::cubeb_log_get_callback(), $crate::LogLevel::Verbose, $($arg),+));
 }
 
 #[macro_export]

--- a/cubeb-core/src/log.rs
+++ b/cubeb-core/src/log.rs
@@ -28,7 +28,7 @@ impl From<ffi::cubeb_log_level> for LogLevel {
 }
 
 pub fn log_enabled() -> bool {
-    unsafe { ffi::g_cubeb_log_level != LogLevel::Disabled as _ }
+    unsafe { ffi::cubeb_log_get_level() != LogLevel::Disabled as _ }
 }
 
 #[cfg(test)]

--- a/cubeb-sys/build.rs
+++ b/cubeb-sys/build.rs
@@ -35,7 +35,7 @@ fn main() {
 
     if !Path::new("libcubeb/.git").exists() {
         let _ = Command::new("git")
-            .args(&["submodule", "update", "--init", "--recursive"])
+            .args(["submodule", "update", "--init", "--recursive"])
             .status();
     }
 

--- a/cubeb-sys/src/log.rs
+++ b/cubeb-sys/src/log.rs
@@ -21,8 +21,8 @@ extern "C" {
         log_callback: cubeb_log_callback,
     ) -> c_int;
 
-    pub static g_cubeb_log_level: cubeb_log_level;
-    pub static g_cubeb_log_callback: cubeb_log_callback;
+    pub fn cubeb_log_get_callback() -> cubeb_log_callback;
+    pub fn cubeb_log_get_level() -> cubeb_log_level;
 
     pub fn cubeb_async_log_reset_threads(_: c_void);
     pub fn cubeb_async_log(msg: *const c_char, ...);

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -33,9 +33,6 @@ fn main() {
         _ => false,
     });
 
-    // g_cubeb_log_* globals aren't visible via cubeb.h, skip them.
-    cfg.skip_static(|s| s.starts_with("g_cubeb_log_"));
-
     // Generate the tests, passing the path to the `*-sys` library as well as
     // the module to generate.
     cfg.generate("../cubeb-sys/src/lib.rs", "all.rs");


### PR DESCRIPTION
No need to bump the version, this is a compilation fix, the public logging API for `cubeb-rs` doesn't change.