### PR TITLE
Use Rust Libs on macOS

### DIFF
--- a/cubeb-sys/build.rs
+++ b/cubeb-sys/build.rs
@@ -47,6 +47,11 @@ fn main() {
     let mut cfg = cmake::Config::new("libcubeb");
 
     if darwin {
+        if !Path::new("libcubeb/src/cubeb-coreaudio-rs").exists() {
+            let _ = Command::new("git")
+                .args(["clone", "https://github.com/mozilla/cubeb-coreaudio-rs.git", "libcubeb/src/cubeb-coreaudio-rs"])
+                .status();
+        }
         let cmake_osx_arch = if target.contains("aarch64") {
             // Apple Silicon
             "arm64"
@@ -55,6 +60,7 @@ fn main() {
             "x86_64"
         };
         cfg.define("CMAKE_OSX_ARCHITECTURES", cmake_osx_arch);
+        cfg.define("BUILD_RUST_LIBS", "ON");
     }
 
     let _ = fs::remove_dir_all(env::var("OUT_DIR").unwrap());


### PR DESCRIPTION
As discussed with @padenot currently on macOS the rust libs don't get built.
This is an attempt to download the rust libs and build them in build.rs according to: https://github.com/mozilla/cubeb-coreaudio-rs/blob/trailblazer/build-audiounit-rust-in-cubeb.sh

```
git clone --recursive https://github.com/mozilla/cubeb.git
cd cubeb/src
git clone https://github.com/mozilla/cubeb-coreaudio-rs.git
cd ../..
mkdir cubeb-build
cd cubeb-build
cmake ../cubeb -DBUILD_RUST_LIBS="ON"
cmake --build .
CUBEB_BACKEND="audiounit-rust" ctest
```

- You have to add an empty ``[workspace]`` after the first build attempt to ``cubeb-sys/libcubeb/src/cubeb-coreaudio-rs/Cargo.toml`` because it needs be disconnected to the main workspace.

- Then the libs get correctly build in ``cubeb-sys/libcubeb/src/cubeb-coreaudio-rs/target/release/libcubeb_coreaudio.a`` and ``cubeb-sys/libcubeb/src/cubeb-coreaudio-rs/target/debug/libcubeb_coreaudio.a`` where the CMake script of cubeb should be looking for it according to CMakeScript line 363.
```
target_link_libraries(cubeb PRIVATE
    debug "${PROJECT_SOURCE_DIR}/src/cubeb-coreaudio-rs/target/debug/libcubeb_coreaudio.a"
    optimized "${PROJECT_SOURCE_DIR}/src/cubeb-coreaudio-rs/target/release/libcubeb_coreaudio.a")
 ```
 
 The linking fails anyways with 
```
note: Undefined symbols for architecture arm64:
            "_audiounit_rust_init", referenced from:
                _cubeb_init in libcubeb_sys-9e0ec07f36791a82.rlib(cubeb.c.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Any ideas for a different strategy?