### PR TITLE
Avoid relying on bitflags internals

### DIFF
--- a/cubeb-core/src/channel.rs
+++ b/cubeb-core/src/channel.rs
@@ -32,7 +32,7 @@ bitflags! {
 
 macro_rules! bits {
     ($($x:ident => $y:ident),*) => {
-        $(pub const $x: ChannelLayout = ChannelLayout { bits: ffi::$y };)*
+        $(pub const $x: ChannelLayout = ChannelLayout::from_bits_truncate(ffi::$y);)*
     }
 }
 
@@ -75,8 +75,7 @@ impl From<ChannelLayout> for ffi::cubeb_channel {
 
 impl ChannelLayout {
     pub fn num_channels(&self) -> u32 {
-        let layout = *self;
-        unsafe { ffi::cubeb_channel_layout_nb_channels(layout.into()) }
+        unsafe { ffi::cubeb_channel_layout_nb_channels(self.bits()) }
     }
 }
 


### PR DESCRIPTION
This will allow to use a bitflags 2-derived bitflags 1 implementation in mozilla-central.