### PR TITLE
Cross-compile for aarch64-linux.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,3 +66,24 @@ jobs:
       shell: bash
       run: rustup run ${{ matrix.rust }} cargo run -p systest
 
+  build_arm_linux:
+    name: Cross-compile for aarch64 linux
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+         submodules: recursive
+
+      - name: Install Rust
+        shell: bash
+        run: rustup target add aarch64-unknown-linux-gnu
+
+      - name: Install crossbuild headers
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y crossbuild-essential-arm64
+
+      - name: Build cross compile aarch64
+        shell: bash
+        run: cargo build --all --target aarch64-unknown-linux-gnu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,4 +86,4 @@ jobs:
 
       - name: Build cross compile aarch64
         shell: bash
-        run: cargo build --all --target aarch64-unknown-linux-gnu
+        run: cargo build --workspace --exclude systest --target aarch64-unknown-linux-gnu

--- a/cubeb-api/src/stream.rs
+++ b/cubeb-api/src/stream.rs
@@ -315,7 +315,7 @@ impl<'a, F> StreamBuilder<'a, F> {
     }
 }
 
-impl<'a, F> Default for StreamBuilder<'a, F> {
+impl<F> Default for StreamBuilder<'_, F> {
     fn default() -> Self {
         StreamBuilder {
             name: None,

--- a/cubeb-core/src/device_collection.rs
+++ b/cubeb-core/src/device_collection.rs
@@ -14,7 +14,7 @@ type CType = ffi::cubeb_device_collection;
 #[derive(Debug)]
 pub struct DeviceCollection<'ctx>(CType, &'ctx ContextRef);
 
-impl<'ctx> DeviceCollection<'ctx> {
+impl DeviceCollection<'_> {
     pub(crate) fn init_with_ctx(ctx: &ContextRef, coll: CType) -> DeviceCollection {
         DeviceCollection(coll, ctx)
     }
@@ -24,7 +24,7 @@ impl<'ctx> DeviceCollection<'ctx> {
     }
 }
 
-impl<'ctx> Drop for DeviceCollection<'ctx> {
+impl Drop for DeviceCollection<'_> {
     fn drop(&mut self) {
         unsafe {
             let _ = call!(ffi::cubeb_device_collection_destroy(
@@ -35,7 +35,7 @@ impl<'ctx> Drop for DeviceCollection<'ctx> {
     }
 }
 
-impl<'ctx> ::std::ops::Deref for DeviceCollection<'ctx> {
+impl ::std::ops::Deref for DeviceCollection<'_> {
     type Target = DeviceCollectionRef;
 
     #[inline]
@@ -45,7 +45,7 @@ impl<'ctx> ::std::ops::Deref for DeviceCollection<'ctx> {
     }
 }
 
-impl<'ctx> ::std::convert::AsRef<DeviceCollectionRef> for DeviceCollection<'ctx> {
+impl ::std::convert::AsRef<DeviceCollectionRef> for DeviceCollection<'_> {
     #[inline]
     fn as_ref(&self) -> &DeviceCollectionRef {
         self


### PR DESCRIPTION
This architecture has a different c_char: u8, rather than i8.

Due to https://github.com/rust-lang/rust/issues/113735, this causes a build breakage, since CStr::from_ptr was documented to take an i8 but actually takes a c_char.