### PR TITLE
Fix build on arm64 linux.

### DIFF
--- a/cubeb-sys/src/device.rs
+++ b/cubeb-sys/src/device.rs
@@ -182,7 +182,7 @@ impl Default for cubeb_device_info {
 
 impl fmt::Debug for cubeb_device_info {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fn optional_c_str(c_str: *const i8) -> Option<*const i8> {
+        fn optional_c_str(c_str: *const c_char) -> Option<*const c_char> {
             (unsafe { c_str.as_ref() }).map(ptr::from_ref)
         }
         f.debug_struct("cubeb_device_info")


### PR DESCRIPTION
On arm64 linux, c_char is u8. CStr::from_ptr is documented to take an i8, but this is not accurate (see
https://github.com/rust-lang/rust/issues/113735); instead, it takes c_char, which is sometimes but not always the same. One time it is different is on aarch64 Linux, so without this commit, cubeb-rs fails to build there.