### PR TITLE
Fix docs.rs build.

### DIFF
--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 repository = "https://github.com/mozilla/cubeb-rs"
 license = "ISC"
 description = "Native bindings to the cubeb library"
-exclude = ["libcubeb/"]
+exclude = ["libcubeb/googletest/"]
 
 links = "cubeb"
 build = "build.rs"


### PR DESCRIPTION
docs.rs runs offline, so it cannot clone libcubeb. Therefore, do not exclude it from the package.