### PR TITLE
Correctly choose profile to use.

### DIFF
--- a/cubeb-sys/build.rs
+++ b/cubeb-sys/build.rs
@@ -113,7 +113,7 @@ fn main() {
         .env("CARGO_BUILD_TARGET", &target)
         .build();
 
-    let debug = env::var("DEBUG").unwrap().parse::<bool>().unwrap();
+    let debug = env::var("PROFILE").unwrap() == "debug";
 
     println!("cargo:rustc-link-lib=static=cubeb");
     if windows {


### PR DESCRIPTION
If, e.g., a user sets `CARGO_PROFILE_RELEASE_DEBUG=1`, the `DEBUG` environment variable will be set accordingly, and so the debug build will be used.

Instead, we should use the PROFILE env variable (see https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts) to determine which profile to use.

This isn't 100% correct, because it won't pass through any other flags (in this case, we won't have debug information for the cubeb backend), but it is more correct to ensure the matching profile.