### PR TITLE
Don't use `Context` and `DeviceCollection` in backend trait

### DIFF
--- a/cubeb-backend/src/capi.rs
+++ b/cubeb-backend/src/capi.rs
@@ -79,9 +79,7 @@ pub unsafe extern "C" fn capi_init<CTX: ContextOps>(
     let anchor = &();
     let context_name = opt_cstr(anchor, context_name);
     let context = _try!(CTX::init(context_name));
-    *c = context.as_ptr();
-    // Leaking pointer across C FFI
-    mem::forget(context);
+    c.write(Box::into_raw(context) as *mut _);
     ffi::CUBEB_OK
 }
 

--- a/cubeb-backend/src/traits.rs
+++ b/cubeb-backend/src/traits.rs
@@ -4,7 +4,7 @@
 // accompanying file LICENSE for details.
 
 use cubeb_core::{
-    DeviceCollectionRef, DeviceId, DeviceRef, DeviceType, InputProcessingParams, Result, Stream,
+    DeviceId, DeviceInfo, DeviceRef, DeviceType, InputProcessingParams, Result, Stream,
     StreamParams, StreamParamsRef,
 };
 use ffi;
@@ -18,12 +18,8 @@ pub trait ContextOps {
     fn min_latency(&mut self, params: StreamParams) -> Result<u32>;
     fn preferred_sample_rate(&mut self) -> Result<u32>;
     fn supported_input_processing_params(&mut self) -> Result<InputProcessingParams>;
-    fn enumerate_devices(
-        &mut self,
-        devtype: DeviceType,
-        collection: &DeviceCollectionRef,
-    ) -> Result<()>;
-    fn device_collection_destroy(&mut self, collection: &mut DeviceCollectionRef) -> Result<()>;
+    fn enumerate_devices(&mut self, devtype: DeviceType) -> Result<Box<[DeviceInfo]>>;
+    fn device_collection_destroy(&mut self, collection: Box<[DeviceInfo]>) -> Result<()>;
     #[allow(clippy::too_many_arguments)]
     fn stream_init(
         &mut self,

--- a/cubeb-backend/src/traits.rs
+++ b/cubeb-backend/src/traits.rs
@@ -4,15 +4,15 @@
 // accompanying file LICENSE for details.
 
 use cubeb_core::{
-    Context, DeviceCollectionRef, DeviceId, DeviceRef, DeviceType, InputProcessingParams, Result,
-    Stream, StreamParams, StreamParamsRef,
+    DeviceCollectionRef, DeviceId, DeviceRef, DeviceType, InputProcessingParams, Result, Stream,
+    StreamParams, StreamParamsRef,
 };
 use ffi;
 use std::ffi::CStr;
 use std::os::raw::c_void;
 
 pub trait ContextOps {
-    fn init(context_name: Option<&CStr>) -> Result<Context>;
+    fn init(context_name: Option<&CStr>) -> Result<Box<Self>>;
     fn backend_id(&mut self) -> &CStr;
     fn max_channel_count(&mut self) -> Result<u32>;
     fn min_latency(&mut self, params: StreamParams) -> Result<u32>;

--- a/cubeb-backend/tests/test_capi.rs
+++ b/cubeb-backend/tests/test_capi.rs
@@ -9,8 +9,8 @@
 extern crate cubeb_backend;
 
 use cubeb_backend::{
-    ffi, Context, ContextOps, DeviceCollectionRef, DeviceId, DeviceRef, DeviceType,
-    InputProcessingParams, Ops, Result, Stream, StreamOps, StreamParams, StreamParamsRef,
+    ffi, ContextOps, DeviceCollectionRef, DeviceId, DeviceRef, DeviceType, InputProcessingParams,
+    Ops, Result, Stream, StreamOps, StreamParams, StreamParamsRef,
 };
 use std::ffi::CStr;
 use std::os::raw::c_void;
@@ -25,11 +25,10 @@ struct TestContext {
 }
 
 impl ContextOps for TestContext {
-    fn init(_context_name: Option<&CStr>) -> Result<Context> {
-        let ctx = Box::new(TestContext {
+    fn init(_context_name: Option<&CStr>) -> Result<Box<Self>> {
+        Ok(Box::new(TestContext {
             ops: &OPS as *const _,
-        });
-        Ok(unsafe { Context::from_ptr(Box::into_raw(ctx) as *mut _) })
+        }))
     }
 
     fn backend_id(&mut self) -> &'static CStr {

--- a/cubeb-core/src/ffi_types.rs
+++ b/cubeb-core/src/ffi_types.rs
@@ -170,6 +170,12 @@ macro_rules! ffi_type_stack {
             }
         }
 
+        impl From<$owned> for $ctype {
+            fn from(x: $owned) -> $ctype {
+                x.0
+            }
+        }
+
         impl ::std::ops::Deref for $owned {
             type Target = $borrowed;
 


### PR DESCRIPTION
These types have RAII semantics which are not useful for trait that is used for C FFI. Using more natural Rust types results in simpler code and fewer `unsafe` blocks as can be seen in the patch for `cubeb-pulse-rs` below. It also allows moving more of the memory management logic into `cubeb-backend`.

<details>
<summary>patch for cubeb-pulse-rs</summary>

```patch
diff --git a/src/backend/context.rs b/src/backend/context.rs
index b9b8176..a886897 100644
--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -5,8 +5,8 @@
 
 use backend::*;
 use cubeb_backend::{
-    ffi, log_enabled, Context, ContextOps, DeviceCollectionRef, DeviceId, DeviceType, Error,
-    InputProcessingParams, Ops, Result, Stream, StreamParams, StreamParamsRef,
+    ffi, log_enabled, ContextOps, DeviceId, DeviceInfo, DeviceType, Error, InputProcessingParams,
+    Ops, Result, Stream, StreamParams, StreamParamsRef,
 };
 use pulse::{self, ProplistExt};
 use pulse_ffi::*;
@@ -14,7 +14,6 @@ use semver;
 use std::cell::RefCell;
 use std::default::Default;
 use std::ffi::{CStr, CString};
-use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
 
@@ -264,9 +263,8 @@ impl PulseContext {
 }
 
 impl ContextOps for PulseContext {
-    fn init(context_name: Option<&CStr>) -> Result<Context> {
-        let ctx = PulseContext::new(context_name)?;
-        Ok(unsafe { Context::from_ptr(Box::into_raw(ctx) as *mut _) })
+    fn init(context_name: Option<&CStr>) -> Result<Box<Self>> {
+        PulseContext::new(context_name)
     }
 
     fn backend_id(&mut self) -> &'static CStr {
@@ -306,11 +304,7 @@ impl ContextOps for PulseContext {
         Ok(InputProcessingParams::NONE)
     }
 
-    fn enumerate_devices(
-        &mut self,
-        devtype: DeviceType,
-        collection: &DeviceCollectionRef,
-    ) -> Result<()> {
+    fn enumerate_devices(&mut self, devtype: DeviceType) -> Result<Box<[DeviceInfo]>> {
         fn add_output_device(
             _: &pulse::Context,
             i: *const pulse::SinkInfo,
@@ -369,7 +363,7 @@ impl ContextOps for PulseContext {
                 latency_lo: 0,
                 latency_hi: 0,
             };
-            list_data.devinfo.push(devinfo);
+            list_data.devinfo.push(devinfo.into());
         }
 
         fn add_input_device(
@@ -431,7 +425,7 @@ impl ContextOps for PulseContext {
                 latency_hi: 0,
             };
 
-            list_data.devinfo.push(devinfo);
+            list_data.devinfo.push(devinfo.into());
         }
 
         fn default_device_names(
@@ -483,38 +477,21 @@ impl ContextOps for PulseContext {
             self.mainloop.unlock();
         }
 
-        // Extract the array of cubeb_device_info from
-        // PulseDevListData and convert it into C representation.
-        let mut tmp = Vec::new();
-        mem::swap(&mut user_data.devinfo, &mut tmp);
-        let mut devices = tmp.into_boxed_slice();
-        let coll = unsafe { &mut *collection.as_ptr() };
-        coll.device = devices.as_mut_ptr();
-        coll.count = devices.len();
-
-        // Giving away the memory owned by devices.  Don't free it!
-        mem::forget(devices);
-        Ok(())
+        Ok(user_data.devinfo.into_boxed_slice())
     }
 
-    fn device_collection_destroy(&mut self, collection: &mut DeviceCollectionRef) -> Result<()> {
-        debug_assert!(!collection.as_ptr().is_null());
-        unsafe {
-            let coll = &mut *collection.as_ptr();
-            let mut devices = Vec::from_raw_parts(coll.device, coll.count, coll.count);
-            for dev in &mut devices {
-                if !dev.group_id.is_null() {
-                    let _ = CString::from_raw(dev.group_id as *mut _);
-                }
-                if !dev.vendor_name.is_null() {
-                    let _ = CString::from_raw(dev.vendor_name as *mut _);
-                }
-                if !dev.friendly_name.is_null() {
-                    let _ = CString::from_raw(dev.friendly_name as *mut _);
-                }
+    fn device_collection_destroy(&mut self, collection: Box<[DeviceInfo]>) -> Result<()> {
+        for dev in collection {
+            let dev = ffi::cubeb_device_info::from(dev);
+            if !dev.group_id.is_null() {
+                let _ = unsafe { CString::from_raw(dev.group_id as *mut _) };
+            }
+            if !dev.vendor_name.is_null() {
+                let _ = unsafe { CString::from_raw(dev.vendor_name as *mut _) };
+            }
+            if !dev.friendly_name.is_null() {
+                let _ = unsafe { CString::from_raw(dev.friendly_name as *mut _) };
             }
-            coll.device = ptr::null_mut();
-            coll.count = 0;
         }
         Ok(())
     }
@@ -722,7 +699,7 @@ impl PulseContext {
 struct PulseDevListData<'a> {
     default_sink_name: CString,
     default_source_name: CString,
-    devinfo: Vec<ffi::cubeb_device_info>,
+    devinfo: Vec<DeviceInfo>,
     context: &'a PulseContext,
 }
 
@@ -740,14 +717,6 @@ impl<'a> PulseDevListData<'a> {
     }
 }
 
-impl Drop for PulseDevListData<'_> {
-    fn drop(&mut self) {
-        for elem in &mut self.devinfo {
-            let _ = unsafe { Box::from_raw(elem) };
-        }
-    }
-}
-
 fn pulse_format_to_cubeb_format(format: pa_sample_format_t) -> ffi::cubeb_device_fmt {
     match format {
         PA_SAMPLE_S16LE => ffi::CUBEB_DEVICE_FMT_S16LE,
```

</details>