### PR TITLE
Update Readme and Cargo.toml info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cubeb-rs [![ISC License](https://img.shields.io/crates/l/cubeb.svg)](https://github.com/djg/cubeb-rs/blob/master/LICENSE)
+# cubeb-rs [![ISC License](https://img.shields.io/crates/l/cubeb.svg)](https://github.com/mozilla/cubeb-rs/blob/master/LICENSE)
 
 A cross-platform audio library in Rust.
 
@@ -28,7 +28,7 @@ supports backend implementations in both pure-Rust and via bindings to the C++
 implementation, allowing for progressive replacement. So far, pure-Rust
 implementations exist for:
 
-- CoreAudio https://github.com/mozilla/cubeb-coreaudio-rs
+- Core Audio https://github.com/mozilla/cubeb-coreaudio-rs
 - PulseAudio https://github.com/mozilla/cubeb-pulse-rs
 
 The plan is to consolidate all **cubeb**-related projects (including backend
@@ -42,9 +42,9 @@ use from projects outside of Gecko is very welcome.
 
 The following crates are included within this repository:
 
-| Crate | Links | Description |
-| --- | --- | --- |
-| `cubeb` | [![crates.io](https://img.shields.io/crates/v/cubeb.svg)](https://crates.io/crates/cubeb) [![docs.rs](https://docs.rs/cubeb/badge.svg)](https://docs.rs/cubeb) | The top-level user API for **cubeb-rs**. See the `cubeb-api` subdirectory. Depends on `cubeb-core`. |
-| `cubeb-core` | [![crates.io](https://img.shields.io/crates/v/cubeb-core.svg)](https://crates.io/crates/cubeb-core) [![docs.rs](https://docs.rs/cubeb-core/badge.svg)](https://docs.rs/cubeb-core) | Common types and definitions for cubeb rust and C bindings. Not intended for direct use. Depends on `cubeb-sys`. |
-| `cubeb-sys` | [![crates.io](https://img.shields.io/crates/v/cubeb-sys.svg)](https://crates.io/crates/cubeb-sys) [![docs.rs](https://docs.rs/cubeb-sys/badge.svg)](https://docs.rs/cubeb-sys) | Native bindings to the cubeb C++ library. Requires `pkg-config` and `cmake` |
-| `cubeb-backend` | [![crates.io](https://img.shields.io/crates/v/cubeb-backend.svg)](https://crates.io/crates/cubeb-backend) [![docs.rs](https://docs.rs/cubeb-backend/badge.svg)](https://docs.rs/cubeb-backend) | Bindings to libcubeb internals to facilitate implementing cubeb backends in Rust. Depends on `cubeb-core`. |
+| Crate           | Links                                                                                                                                                                                          | Description                                                                                                      |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `cubeb`         | [![crates.io](https://img.shields.io/crates/v/cubeb.svg)](https://crates.io/crates/cubeb) [![docs.rs](https://docs.rs/cubeb/badge.svg)](https://docs.rs/cubeb)                                 | The top-level user API for **cubeb-rs**. See the `cubeb-api` subdirectory. Depends on `cubeb-core`.              |
+| `cubeb-core`    | [![crates.io](https://img.shields.io/crates/v/cubeb-core.svg)](https://crates.io/crates/cubeb-core) [![docs.rs](https://docs.rs/cubeb-core/badge.svg)](https://docs.rs/cubeb-core)             | Common types and definitions for cubeb Rust and C bindings. Not intended for direct use. Depends on `cubeb-sys`. |
+| `cubeb-sys`     | [![crates.io](https://img.shields.io/crates/v/cubeb-sys.svg)](https://crates.io/crates/cubeb-sys) [![docs.rs](https://docs.rs/cubeb-sys/badge.svg)](https://docs.rs/cubeb-sys)                 | Native bindings to the cubeb C++ library. Requires `pkg-config` and `cmake`.                                     |
+| `cubeb-backend` | [![crates.io](https://img.shields.io/crates/v/cubeb-backend.svg)](https://crates.io/crates/cubeb-backend) [![docs.rs](https://docs.rs/cubeb-backend/badge.svg)](https://docs.rs/cubeb-backend) | Bindings to libcubeb internals to facilitate implementing cubeb backends in Rust. Depends on `cubeb-core`.       |

--- a/cubeb-api/Cargo.toml
+++ b/cubeb-api/Cargo.toml
@@ -8,12 +8,9 @@ keywords = ["cubeb"]
 repository = "https://github.com/mozilla/cubeb-rs"
 homepage = "https://github.com/mozilla/cubeb-rs"
 description = """
-Bindings to libcubeb for interacting with system audio from rust.
+Bindings to libcubeb for interacting with system audio from Rust.
 """
 categories = ["api-bindings"]
-
-[badges]
-circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]

--- a/cubeb-api/README.md
+++ b/cubeb-api/README.md
@@ -1,14 +1,14 @@
 # cubeb-rs
 
-[![Build Status](https://travis-ci.org/djg/cubeb-rs.svg?branch=master)](https://travis-ci.org/djg/cubeb-rs)
+[![Build Status](https://github.com/mozilla/cubeb-rs/actions/workflows/build.yml/badge.svg)](https://github.com/mozilla/cubeb-rs/actions)
 
 [Documentation](https://docs.rs/cubeb)
 
-cubeb bindings for Rust
+cubeb bindings for Rust.
 
 ```toml
 [dependencies]
-cubeb = "0.1"
+cubeb = "0.31"
 ```
 
 ## Building cubeb-rs
@@ -16,11 +16,11 @@ cubeb = "0.1"
 First, you'll need to install _CMake_. Afterwards, just run:
 
 ```sh
-$ git clone https://github.com/djg/cubeb-rs
+$ git clone https://github.com/mozilla/cubeb-rs
 $ cd cubeb-rs
 $ cargo build
 ```
 
 # License
 
-`cubeb-rs` is distributed under an ISC-style license.  See LICENSE for details.
+`cubeb-rs` is distributed under an ISC-style license. See LICENSE for details.

--- a/cubeb-backend/Cargo.toml
+++ b/cubeb-backend/Cargo.toml
@@ -7,12 +7,9 @@ keywords = ["cubeb"]
 repository = "https://github.com/mozilla/cubeb-rs"
 homepage = "https://github.com/mozilla/cubeb-rs"
 description = """
-Bindings to libcubeb internals to facilitate implementing cubeb backends in rust.
+Bindings to libcubeb internals to facilitate implementing cubeb backends in Rust.
 """
 categories = ["api-bindings"]
-
-[badges]
-circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]

--- a/cubeb-core/Cargo.toml
+++ b/cubeb-core/Cargo.toml
@@ -7,12 +7,9 @@ keywords = ["cubeb"]
 repository = "https://github.com/mozilla/cubeb-rs"
 homepage = "https://github.com/mozilla/cubeb-rs"
 description = """
-Common types and definitions for cubeb rust and C bindings. Not intended for direct use.
+Common types and definitions for cubeb Rust and C bindings. Not intended for direct use.
 """
 categories = ["api-bindings"]
-
-[badges]
-circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-sys/gecko-in-tree"]

--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -4,14 +4,11 @@ version = "0.31.1"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 repository = "https://github.com/mozilla/cubeb-rs"
 license = "ISC"
-description = "Native bindings to the cubeb library"
+description = "Native bindings to the cubeb library."
 exclude = ["libcubeb/googletest"]
 
 links = "cubeb"
 build = "build.rs"
-
-[badges]
-circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = []


### PR DESCRIPTION
Changes:

- Update URLs
- Remove obsolete CircleCI references
- Replace obsolete Travis CI badge with GitHub workflow badge
- Update listed cubeb version number in Readme
- Minor formatting fixes