### PR TITLE
Fix Miri Stacked Borrows violation in ffi wrapper macros

### DIFF
--- a/cubeb-backend/tests/test_capi.rs
+++ b/cubeb-backend/tests/test_capi.rs
@@ -67,7 +67,10 @@ impl ContextOps for TestContext {
         _state_callback: ffi::cubeb_state_callback,
         _user_ptr: *mut c_void,
     ) -> Result<Stream> {
-        Ok(unsafe { Stream::from_ptr(0xDEAD_BEEF as *mut _) })
+        let stm = Box::new(TestStream {
+            device: Default::default(),
+        });
+        Ok(unsafe { Stream::from_ptr(Box::into_raw(stm) as *mut _) })
     }
     fn register_device_collection_changed(
         &mut self,
@@ -79,7 +82,9 @@ impl ContextOps for TestContext {
     }
 }
 
-struct TestStream {}
+struct TestStream {
+    device: ffi::cubeb_device,
+}
 
 impl StreamOps for TestStream {
     fn start(&mut self) -> Result<()> {
@@ -106,7 +111,7 @@ impl StreamOps for TestStream {
         Ok(())
     }
     fn current_device(&mut self) -> Result<&DeviceRef> {
-        Ok(unsafe { DeviceRef::from_ptr(0xDEAD_BEEF as *mut _) })
+        Ok(unsafe { DeviceRef::from_ptr(&mut self.device as *mut _) })
     }
     fn set_input_mute(&mut self, mute: bool) -> Result<()> {
         assert_eq!(mute, true);
@@ -117,7 +122,7 @@ impl StreamOps for TestStream {
         Ok(())
     }
     fn device_destroy(&mut self, device: &DeviceRef) -> Result<()> {
-        assert_eq!(device.as_ptr(), 0xDEAD_BEEF as *mut _);
+        assert_eq!(device.as_ptr(), &self.device as *const _ as *mut _);
         Ok(())
     }
     fn register_device_changed_callback(
@@ -257,7 +262,11 @@ fn test_ops_stream_current_device() {
         unsafe { OPS.stream_get_current_device.unwrap()(s, &mut device) },
         ffi::CUBEB_OK
     );
-    assert_eq!(device, 0xDEAD_BEEF as *mut _);
+    assert!(!device.is_null());
+    assert_eq!(
+        unsafe { OPS.stream_device_destroy.unwrap()(s, device) },
+        ffi::CUBEB_OK
+    );
 }
 
 #[test]

--- a/cubeb-core/src/device.rs
+++ b/cubeb-core/src/device.rs
@@ -231,7 +231,8 @@ mod tests {
 
     #[test]
     fn device_device_ref_same_ptr() {
-        let ptr: *mut cubeb_device = 0xDEAD_BEEF as *mut _;
+        let raw = cubeb_device::default();
+        let ptr = &raw as *const cubeb_device as *mut cubeb_device;
         let device = unsafe { Device::from_ptr(ptr) };
         assert_eq!(device.as_ptr(), ptr);
         assert_eq!(device.as_ptr(), device.as_ref().as_ptr());

--- a/cubeb-core/src/device_collection.rs
+++ b/cubeb-core/src/device_collection.rs
@@ -52,7 +52,8 @@ impl ::std::convert::AsRef<DeviceCollectionRef> for DeviceCollection<'_> {
     }
 }
 
-pub struct DeviceCollectionRef(ffi_types::Opaque);
+#[repr(transparent)]
+pub struct DeviceCollectionRef(ffi_types::Opaque<CType>);
 
 impl DeviceCollectionRef {
     /// # Safety
@@ -75,13 +76,13 @@ impl DeviceCollectionRef {
 
     #[inline]
     pub fn as_ptr(&self) -> *mut CType {
-        self as *const _ as *mut _
+        self.0.get().cast()
     }
 }
 
 impl ::std::fmt::Debug for DeviceCollectionRef {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        let ptr = self as *const DeviceCollectionRef as usize;
+        let ptr = self.0.get() as usize;
         f.debug_tuple(stringify!(DeviceCollectionRef))
             .field(&ptr)
             .finish()

--- a/cubeb-core/src/ffi_types.rs
+++ b/cubeb-core/src/ffi_types.rs
@@ -4,7 +4,9 @@
 // accompanying file LICENSE for details.
 
 use std::cell::UnsafeCell;
-pub struct Opaque(UnsafeCell<()>);
+use std::mem::MaybeUninit;
+
+pub type Opaque<T> = UnsafeCell<MaybeUninit<T>>;
 
 /// Generate a newtype wrapper `$owned` and reference wrapper
 /// `$borrowed` around a POD FFI type that lives on the heap.
@@ -101,7 +103,8 @@ macro_rules! ffi_type_heap {
         }
 
         $(#[$borrowed_attr])*
-        pub struct $borrowed($crate::ffi_types::Opaque);
+        #[repr(transparent)]
+        pub struct $borrowed($crate::ffi_types::Opaque<$ctype>);
 
         impl $borrowed {
             /// # Safety
@@ -124,13 +127,13 @@ macro_rules! ffi_type_heap {
 
             #[inline]
             pub fn as_ptr(&self) -> *mut $ctype {
-                self as *const _ as *mut _
+                self.0.get().cast()
             }
         }
 
         impl ::std::fmt::Debug for $borrowed {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                let ptr = self as *const $borrowed as usize;
+                let ptr = self.0.get() as usize;
                 f.debug_tuple(stringify!($borrowed))
                     .field(&ptr)
                     .finish()
@@ -209,7 +212,8 @@ macro_rules! ffi_type_stack {
         }
 
         $(#[$borrowed_attr])*
-        pub struct $borrowed($crate::ffi_types::Opaque);
+        #[repr(transparent)]
+        pub struct $borrowed($crate::ffi_types::Opaque<$ctype>);
 
         impl $borrowed {
             /// # Safety
@@ -232,13 +236,13 @@ macro_rules! ffi_type_stack {
 
             #[inline]
             pub fn as_ptr(&self) -> *mut $ctype {
-                self as *const _ as *mut _
+                self.0.get().cast()
             }
         }
 
         impl ::std::fmt::Debug for $borrowed {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                let ptr = self as *const $borrowed as usize;
+                let ptr = self.0.get() as usize;
                 f.debug_tuple(stringify!($borrowed))
                     .field(&ptr)
                     .finish()


### PR DESCRIPTION
The Opaque ZST wrapper (UnsafeCell<()>) used for borrowed FFI reference types caused zero-byte borrow tags under Miri's Stacked Borrows model. Any pointer derived from &StreamParamsRef (or other *Ref types) inherited this zero-byte tag, making all reads through it undefined behavior.

Replace Opaque with MaybeUninit<$ctype> so each borrowed type has the same size and alignment as its underlying C type, ensuring borrow tags cover the actual data bytes. Apply the same fix to DeviceCollectionRef which used Opaque directly.

Updated tests that used sentinel pointers to use valid allocations.