### PR TITLE
Fix cubeb_async_log_reset_threads declaration.

### DIFF
--- a/cubeb-sys/src/log.rs
+++ b/cubeb-sys/src/log.rs
@@ -3,7 +3,7 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use std::os::raw::{c_char, c_int, c_void};
+use std::os::raw::{c_char, c_int};
 
 cubeb_enum! {
     pub enum cubeb_log_level {
@@ -24,6 +24,6 @@ extern "C" {
     pub fn cubeb_log_get_callback() -> cubeb_log_callback;
     pub fn cubeb_log_get_level() -> cubeb_log_level;
 
-    pub fn cubeb_async_log_reset_threads(_: c_void);
+    pub fn cubeb_async_log_reset_threads();
     pub fn cubeb_async_log(msg: *const c_char, ...);
 }


### PR DESCRIPTION
This matches [what cubeb declares](https://github.com/mozilla/cubeb/blob/774182f2c1b6d5e0d8ce975f2ed9f58fab7f1da2/src/cubeb_log.h#L47). cubeb's declaration [used to be](https://github.com/mozilla/cubeb/commit/c4f7e5604cf09f9e48d578b71a57eb460491d768) ambiguous depending on whether the header was compiled as C or C++.