### PR TITLE
Provide a way to prevent inclusion of code that relies on private APIs in coreaudio

### DIFF
--- a/cubeb-api/Cargo.toml
+++ b/cubeb-api/Cargo.toml
@@ -17,6 +17,7 @@ circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
+no-private-apis = ["cubeb-core/no-private-apis"]
 
 [dependencies]
 cubeb-core = { path = "../cubeb-core", version = "0.34.1" }

--- a/cubeb-api/Cargo.toml
+++ b/cubeb-api/Cargo.toml
@@ -17,7 +17,7 @@ circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
-no-private-apis = ["cubeb-core/no-private-apis"]
+no-private-apis-in-coreaudio = ["cubeb-core/no-private-apis-in-coreaudio"]
 
 [dependencies]
 cubeb-core = { path = "../cubeb-core", version = "0.34.1" }

--- a/cubeb-backend/Cargo.toml
+++ b/cubeb-backend/Cargo.toml
@@ -16,6 +16,7 @@ circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
+no-private-apis = ["cubeb-core/no-private-apis"]
 
 [dependencies]
 cubeb-core = { path = "../cubeb-core", version = "0.34.1" }

--- a/cubeb-backend/Cargo.toml
+++ b/cubeb-backend/Cargo.toml
@@ -16,7 +16,7 @@ circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-core/gecko-in-tree"]
-no-private-apis = ["cubeb-core/no-private-apis"]
+no-private-apis-in-coreaudio = ["cubeb-core/no-private-apis-in-coreaudio"]
 
 [dependencies]
 cubeb-core = { path = "../cubeb-core", version = "0.34.1" }

--- a/cubeb-core/Cargo.toml
+++ b/cubeb-core/Cargo.toml
@@ -16,6 +16,7 @@ circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-sys/gecko-in-tree"]
+no-private-apis = ["cubeb-sys/no-private-apis"]
 
 [dependencies]
 bitflags = "1.2.0"

--- a/cubeb-core/Cargo.toml
+++ b/cubeb-core/Cargo.toml
@@ -16,7 +16,7 @@ circle-ci = { repository = "mozilla/cubeb-rs" }
 
 [features]
 gecko-in-tree = ["cubeb-sys/gecko-in-tree"]
-no-private-apis = ["cubeb-sys/no-private-apis"]
+no-private-apis-in-coreaudio = ["cubeb-sys/no-private-apis-in-coreaudio"]
 
 [dependencies]
 bitflags = "1.2.0"

--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -16,7 +16,7 @@ circle-ci = { repository = "mozilla/cubeb-rs" }
 [features]
 gecko-in-tree = []
 unittest-build = []
-no-private-apis = []
+no-private-apis-in-coreaudio = []
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -16,6 +16,7 @@ circle-ci = { repository = "mozilla/cubeb-rs" }
 [features]
 gecko-in-tree = []
 unittest-build = []
+no-private-apis = []
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/cubeb-sys/build.rs
+++ b/cubeb-sys/build.rs
@@ -115,6 +115,8 @@ fn main() {
         cfg.define("CMAKE_OSX_ARCHITECTURES", cmake_osx_arch);
     }
 
+    let no_private_apis = cfg!(feature = "no-private-apis");
+
     // Do not build the rust backends for tests: doing so causes duplicate
     // symbol definitions.
     let build_rust_libs = cfg!(not(feature = "unittest-build")) && env::var("DOCS_RS").is_err();
@@ -127,6 +129,10 @@ fn main() {
             if build_rust_libs { "ON" } else { "OFF" },
         )
         .define("USE_STATIC_MSVC_RUNTIME", "ON")
+        .define(
+            "NO_PRIVATE_APIS_IN_COREAUDIO",
+            if no_private_apis { "ON" } else { "OFF" },
+        )
         // Force rust libs to include target triple when outputting,
         // for easier linking when cross-compiling.
         .env("CARGO_BUILD_TARGET", &target)

--- a/cubeb-sys/build.rs
+++ b/cubeb-sys/build.rs
@@ -115,7 +115,7 @@ fn main() {
         cfg.define("CMAKE_OSX_ARCHITECTURES", cmake_osx_arch);
     }
 
-    let no_private_apis = cfg!(feature = "no-private-apis");
+    let no_private_apis_in_coreaudio = cfg!(feature = "no-private-apis-in-coreaudio");
 
     // Do not build the rust backends for tests: doing so causes duplicate
     // symbol definitions.
@@ -131,7 +131,11 @@ fn main() {
         .define("USE_STATIC_MSVC_RUNTIME", "ON")
         .define(
             "NO_PRIVATE_APIS_IN_COREAUDIO",
-            if no_private_apis { "ON" } else { "OFF" },
+            if no_private_apis_in_coreaudio {
+                "ON"
+            } else {
+                "OFF"
+            },
         )
         // Force rust libs to include target triple when outputting,
         // for easier linking when cross-compiling.


### PR DESCRIPTION
For more information see https://github.com/mozilla/cubeb-coreaudio-rs/pull/283 and https://github.com/mozilla/cubeb/pull/846.