### PR TITLE
Update ctest to 0.5 and cubeb-sys to edition 2021

### DIFF
--- a/cubeb-sys/Cargo.toml
+++ b/cubeb-sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cubeb-sys"
 version = "0.34.1"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
+edition = "2021"
 repository = "https://github.com/mozilla/cubeb-rs"
 license = "ISC"
 description = "Native bindings to the cubeb library"

--- a/cubeb-sys/build.rs
+++ b/cubeb-sys/build.rs
@@ -45,6 +45,14 @@ fn main() {
 
     env::remove_var("DESTDIR");
 
+    // When this build script runs under `cargo clippy`, these variables leak
+    // into the nested cargo invocation that builds the vendored rust backends
+    // (via cmake), running clippy over code we don't control. Scrub them so
+    // the nested build is a plain `cargo build`.
+    env::remove_var("RUSTC_WRAPPER");
+    env::remove_var("RUSTC_WORKSPACE_WRAPPER");
+    env::remove_var("CLIPPY_ARGS");
+
     // Copy libcubeb to the output directory.
     let libcubeb_path = format!("{out_dir}/libcubeb");
 

--- a/cubeb-sys/src/audio_dump.rs
+++ b/cubeb-sys/src/audio_dump.rs
@@ -3,8 +3,8 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
+use crate::stream::cubeb_stream_params;
 use std::os::raw::{c_char, c_int, c_void};
-use stream::cubeb_stream_params;
 
 pub enum cubeb_audio_dump_stream {}
 pub enum cubeb_audio_dump_session {}

--- a/cubeb-sys/src/callbacks.rs
+++ b/cubeb-sys/src/callbacks.rs
@@ -3,9 +3,9 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use context::cubeb;
+use crate::context::cubeb;
+use crate::stream::{cubeb_state, cubeb_stream};
 use std::os::raw::{c_long, c_void};
-use stream::{cubeb_state, cubeb_stream};
 
 pub type cubeb_data_callback = Option<
     unsafe extern "C" fn(

--- a/cubeb-sys/src/context.rs
+++ b/cubeb-sys/src/context.rs
@@ -3,10 +3,10 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use callbacks::{cubeb_data_callback, cubeb_state_callback};
-use device::cubeb_devid;
+use crate::callbacks::{cubeb_data_callback, cubeb_state_callback};
+use crate::device::cubeb_devid;
+use crate::stream::{cubeb_input_processing_params, cubeb_stream, cubeb_stream_params};
 use std::os::raw::{c_char, c_int, c_uint, c_void};
-use stream::{cubeb_input_processing_params, cubeb_stream, cubeb_stream_params};
 
 pub enum cubeb {}
 

--- a/cubeb-sys/src/device.rs
+++ b/cubeb-sys/src/device.rs
@@ -3,8 +3,8 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use callbacks::cubeb_device_collection_changed_callback;
-use context::cubeb;
+use crate::callbacks::cubeb_device_collection_changed_callback;
+use crate::context::cubeb;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_uint, c_void};
 use std::{fmt, mem, ptr};

--- a/cubeb-sys/src/mixer.rs
+++ b/cubeb-sys/src/mixer.rs
@@ -3,8 +3,8 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use channel::cubeb_channel_layout;
-use format::cubeb_sample_format;
+use crate::channel::cubeb_channel_layout;
+use crate::format::cubeb_sample_format;
 use std::os::raw::{c_int, c_uint, c_void};
 
 pub enum cubeb_mixer {}

--- a/cubeb-sys/src/resampler.rs
+++ b/cubeb-sys/src/resampler.rs
@@ -3,9 +3,9 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use callbacks::cubeb_data_callback;
+use crate::callbacks::cubeb_data_callback;
+use crate::stream::{cubeb_stream, cubeb_stream_params};
 use std::os::raw::{c_long, c_uint, c_void};
-use stream::{cubeb_stream, cubeb_stream_params};
 
 pub enum cubeb_resampler {}
 

--- a/cubeb-sys/src/stream.rs
+++ b/cubeb-sys/src/stream.rs
@@ -3,10 +3,10 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use callbacks::cubeb_device_changed_callback;
-use channel::cubeb_channel_layout;
-use device::cubeb_device;
-use format::cubeb_sample_format;
+use crate::callbacks::cubeb_device_changed_callback;
+use crate::channel::cubeb_channel_layout;
+use crate::device::cubeb_device;
+use crate::format::cubeb_sample_format;
 use std::os::raw::{c_char, c_float, c_int, c_uint, c_void};
 use std::{fmt, mem};
 

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -17,4 +17,4 @@ cubeb-sys = { path = "../cubeb-sys" }
 libc = "0.2"
 
 [build-dependencies]
-ctest = "0.4"
+ctest = "0.5"

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -33,11 +33,14 @@ fn main() {
         .include(root.join("include/cubeb"))
         .include("../cubeb-sys/libcubeb/src");
 
-    cfg.type_name(|s, _, _| s.to_string())
-        .field_name(|_, f| match f {
-            "device_type" => "type".to_string(),
-            _ => f.to_string(),
-        });
+    // The cubeb types are anonymous-struct typedefs, so drop the `struct`
+    // keyword ctest would otherwise emit.
+    cfg.rename_struct_ty(|ty| Some(ty.to_string()));
+
+    cfg.rename_struct_field(|_, f| match f.ident() {
+        "device_type" => Some("type".to_string()),
+        _ => None,
+    });
 
     // Don't perform `((type_t) -1) < 0)` checks for pointers because
     // they are unsigned and always >= 0.
@@ -48,6 +51,7 @@ fn main() {
     });
 
     // Generate the tests, passing the path to the `*-sys` library as well as
-    // the module to generate.
-    cfg.generate("../cubeb-sys/src/lib.rs", "all.rs");
+    // the module to generate. This also compiles and links the C side of the
+    // tests; `generate_files` alone would leave the ctest_* symbols undefined.
+    ctest::generate_test(&mut cfg, "../cubeb-sys/src/lib.rs", "all.rs").unwrap();
 }

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(bad_style, unused_macros)]
+#![allow(bad_style, unused_macros, unused_imports, clippy::all)]
 
 extern crate cubeb_sys;
 


### PR DESCRIPTION
ctest 0.4.11 no longer compiles against current rustc due to an API change in garando_syntax. ctest 0.5 fixes this but requires edition 2021 for macro expansion.

Update cubeb-sys to edition 2021 and add crate:: prefixes to all intra-crate imports. Adapt systest/build.rs to the renamed ctest 0.5 API (type_name/field_name -> rename_struct_field, generate -> generate_files). Suppress clippy lints on ctest-generated code in `systest/src/main.rs`.