### PR TITLE
cubeb-sys: pin nested rust backend builds to a controlled target dir

### DIFF
--- a/cubeb-sys/build.rs
+++ b/cubeb-sys/build.rs
@@ -112,6 +112,14 @@ fn main() {
     let android = target.contains("android");
     let mut cfg = cmake::Config::new(&libcubeb_path);
 
+    // Pin the nested Rust backend cargo builds (cubeb-pulse-rs / cubeb-coreaudio-rs,
+    // invoked by CMake ExternalProject as plain `cargo build`) to a target dir we
+    // control. Without this they inherit an ambient CARGO_TARGET_DIR or a
+    // `target-dir` set in the user's cargo config, which relocates the produced
+    // static libs away from the rustc-link-search paths emitted below and breaks
+    // linking with "could not find native static library `cubeb_pulse`".
+    let rust_target_dir = format!("{out_dir}/rust-backend-target");
+
     if darwin {
         let cmake_osx_arch = if target.contains("aarch64") {
             // Apple Silicon
@@ -148,6 +156,7 @@ fn main() {
         // Force rust libs to include target triple when outputting,
         // for easier linking when cross-compiling.
         .env("CARGO_BUILD_TARGET", &target)
+        .env("CARGO_TARGET_DIR", &rust_target_dir)
         .build();
 
     let debug = env::var("PROFILE").unwrap() == "debug";
@@ -173,15 +182,12 @@ fn main() {
         // symbol definitions.
         if build_rust_libs {
             println!("cargo:rustc-link-lib=static=cubeb_coreaudio");
-            let mut search_path = std::env::current_dir().unwrap();
-            search_path.push(&(libcubeb_path + "/src/cubeb-coreaudio-rs/target"));
-            search_path.push(&target);
-            if debug {
-                search_path.push("debug");
-            } else {
-                search_path.push("release");
+            // The nested build's profile subdir (debug vs release) follows the
+            // CMake build type, which is derived from opt-level and can differ
+            // from this crate's PROFILE; search both so either one lands the lib.
+            for profile in ["debug", "release"] {
+                println!("cargo:rustc-link-search=native={rust_target_dir}/{target}/{profile}");
             }
-            println!("cargo:rustc-link-search=native={}", search_path.display());
         }
 
         println!("cargo:rustc-link-search=native={}/lib", dst.display());
@@ -202,15 +208,12 @@ fn main() {
             // symbol definitions.
             if build_rust_libs {
                 println!("cargo:rustc-link-lib=static=cubeb_pulse");
-                let mut search_path = std::env::current_dir().unwrap();
-                search_path.push(&(libcubeb_path + "/src/cubeb-pulse-rs/target"));
-                search_path.push(&target);
-                if debug {
-                    search_path.push("debug");
-                } else {
-                    search_path.push("release");
+                // The nested build's profile subdir (debug vs release) follows the
+                // CMake build type, which is derived from opt-level and can differ
+                // from this crate's PROFILE; search both so either one lands the lib.
+                for profile in ["debug", "release"] {
+                    println!("cargo:rustc-link-search=native={rust_target_dir}/{target}/{profile}");
                 }
-                println!("cargo:rustc-link-search=native={}", search_path.display());
             }
         }
         let _ = pkg_config::find_library("jack");


### PR DESCRIPTION
## Problem

Building any project that depends on `cubeb-sys` fails to link when the environment has an ambient `CARGO_TARGET_DIR`, or a `target-dir` set in a cargo config (`~/.cargo/config.toml` or a workspace `.cargo/config.toml`):

```
error: could not find native static library `cubeb_pulse`, perhaps an -L flag is missing?
error: could not compile `cubeb-sys` (lib)
```

(`cubeb_coreaudio` on macOS.)

## Cause

The Rust audio backends (`cubeb-pulse-rs`, `cubeb-coreaudio-rs`) are built by the libcubeb CMake `ExternalProject` via a plain `cargo build`. That nested build honors the ambient `CARGO_TARGET_DIR` / cargo-config `target-dir`, so the produced static libraries land in that directory instead of the in-tree `target/`.

But `build.rs` emits a `rustc-link-search` path computed relative to `OUT_DIR` (`<OUT_DIR>/libcubeb/src/cubeb-<backend>-rs/target/<triple>/<profile>`), assuming the nested build used the default in-tree `target/`. When a `target-dir` is configured, the produced lib and the search path diverge and linking fails. Stock setups (no `target-dir` override) work, which is why this is intermittent and setup-dependent.

There is also a secondary profile-subdir mismatch: the nested build's profile follows the CMake build type (derived from opt-level), which can differ from this crate's `PROFILE`, so `build.rs` occasionally searches `release/` while the lib is under `debug/`.

## Fix

Set `CARGO_TARGET_DIR` for the nested backend builds to a directory under `OUT_DIR` that `build.rs` controls, and point the `rustc-link-search` paths at that same directory. The location is then independent of ambient cargo configuration. Also emit search paths for both the `debug` and `release` profile subdirectories so the profile mismatch can't bite either.

One file changed (`cubeb-sys/build.rs`), no behavior change on setups that already worked.

## Reproduce

```sh
mkdir -p ~/.cargo && printf '[build]\ntarget-dir = "/tmp/shared-target"\n' >> ~/.cargo/config.toml
cargo build   # in any crate depending on cubeb-sys, on Linux with libpulse -> link error
```